### PR TITLE
Add support for proxy authentication

### DIFF
--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Utilities\SymbolIdService.cs" />
     <Compile Include="Utilities\SymbolKindText.cs" />
     <Compile Include="Utilities\SymbolSorter.cs" />
+    <Compile Include="Utilities\WebProxyAuthenticator.cs" />
     <Compile Include="Utilities\WorkspaceHacks.cs" />
     <Compile Include="Utilities\XmlDocumentationProvider.cs" />
   </ItemGroup>

--- a/src/HtmlGenerator/Pass1-Generation/Federation.cs
+++ b/src/HtmlGenerator/Pass1-Generation/Federation.cs
@@ -22,15 +22,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         public Federation(params string[] servers)
         {
-            if (servers == null)
+            if (servers == null || servers.Length > 0)
             {
                 return;
             }
 
-            if (servers.Length > 0)
-            {
-                WebProxyAuthenticator.Authenticate(this.GetAssemblyUrl(servers[0]));
-            }
+            WebProxyAuthenticator.Authenticate(this.GetAssemblyUrl(servers[0]));
 
             foreach (var server in servers)
             {

--- a/src/HtmlGenerator/Pass1-Generation/Federation.cs
+++ b/src/HtmlGenerator/Pass1-Generation/Federation.cs
@@ -2,32 +2,48 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using Microsoft.SourceBrowser.HtmlGenerator.Utilities;
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
     public class Federation
     {
-        private readonly string[] servers;
+        public static IEnumerable<string> FederatedIndexUrls = new[] { @"http://referencesource.microsoft.com", @"http://source.roslyn.io" };
+
         private List<HashSet<string>> assemblies = new List<HashSet<string>>();
+
+        public Federation(IEnumerable<string> servers) : this(servers.ToArray())
+        {
+        }
 
         public Federation(params string[] servers)
         {
-            this.servers = servers;
+            WebProxyAuthenticator.Authenticate(this.GetAssemblyUrl(servers[0]));
+
             foreach (var server in servers)
             {
-                var url = server;
-                if (!url.EndsWith("/"))
-                {
-                    url += "/";
-                }
+                var url = this.GetAssemblyUrl(server);
 
-                var assemblyList = new WebClient().DownloadString(url + "Assemblies.txt");
+                var assemblyList = new WebClient().DownloadString(url);
                 var assemblyNames = new HashSet<string>(assemblyList
                     .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(line => line.Split(';')[0]), StringComparer.OrdinalIgnoreCase);
 
                 assemblies.Add(assemblyNames);
             }
+        }
+
+        private string GetAssemblyUrl(string server)
+        {
+            var url = server;
+            if (!url.EndsWith("/"))
+            {
+                url += "/";
+            }
+
+            url += "Assemblies.txt";
+
+            return url;
         }
 
         public int GetExternalAssemblyIndex(string assemblyName)
@@ -42,5 +58,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             return -1;
         }
+
+        
+
     }
 }

--- a/src/HtmlGenerator/Pass1-Generation/Federation.cs
+++ b/src/HtmlGenerator/Pass1-Generation/Federation.cs
@@ -12,13 +12,25 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private List<HashSet<string>> assemblies = new List<HashSet<string>>();
 
+        public Federation() : this(FederatedIndexUrls)
+        {
+        }
+
         public Federation(IEnumerable<string> servers) : this(servers.ToArray())
         {
         }
 
         public Federation(params string[] servers)
         {
-            WebProxyAuthenticator.Authenticate(this.GetAssemblyUrl(servers[0]));
+            if (servers == null)
+            {
+                return;
+            }
+
+            if (servers.Length > 0)
+            {
+                WebProxyAuthenticator.Authenticate(this.GetAssemblyUrl(servers[0]));
+            }
 
             foreach (var server in servers)
             {

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.SourceBrowser.Common;
+using Microsoft.SourceBrowser.HtmlGenerator.Utilities;
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
-    using Microsoft.SourceBrowser.HtmlGenerator.Utilities;
 
     class Program
     {

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.SourceBrowser.Common;
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
+    using Microsoft.SourceBrowser.HtmlGenerator.Utilities;
+
     class Program
     {
         static void Main(string[] args)
@@ -15,6 +17,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 PrintUsage();
                 return;
             }
+
+            WebProxyAuthenticator.Authenticate("http://referencesource.microsoft.com");
 
             var projects = new List<string>();
             foreach (var arg in args)

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.SourceBrowser.Common;
-using Microsoft.SourceBrowser.HtmlGenerator.Utilities;
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
@@ -17,8 +16,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 PrintUsage();
                 return;
             }
-
-            WebProxyAuthenticator.Authenticate("http://referencesource.microsoft.com");
 
             var projects = new List<string>();
             foreach (var arg in args)
@@ -106,9 +103,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         Paths.SolutionDestinationFolder,
                         solutionInfo.UrlRoot,
                         solutionInfo.MSBuildProperties != null ? solutionInfo.MSBuildProperties.ToImmutableDictionary() : null,
-                        new Federation(
-                            "http://referencesource.microsoft.com",
-                            "http://source.roslyn.io"));
+                        new Federation(Federation.FederatedIndexUrls));
                     needToCallAgain = solutionGenerator.Generate(assemblyList);
                     solutionGenerator.GenerateResultsHtml(assemblyList);
                 } while (needToCallAgain);

--- a/src/HtmlGenerator/Utilities/WebProxyAuthenticator.cs
+++ b/src/HtmlGenerator/Utilities/WebProxyAuthenticator.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Net;
+using System.Security;
+
+namespace Microsoft.SourceBrowser.HtmlGenerator.Utilities
+{
+    /// <summary>
+    /// WebProxyAuthenticator will determine if proxy authentication is required.
+    /// If it is, the user will be asked for the credentials.
+    /// </summary>
+    public class WebProxyAuthenticator
+    {
+
+        /// <summary>
+        /// Determine if there is a proxy that requires credentials.
+        /// If there is, ask the user for the credentials and apply them to WebRequest.DefaultWebProxy
+        /// </summary>
+        /// <param name="url">URL to be used for testing if proxy auth is required</param>
+        public static void Authenticate(string url)
+        {
+            while (!ProxyAuthSuccess(url))
+            {
+                InitialiseProxyAuth();
+            }
+        }
+
+        private static bool ProxyAuthSuccess(string url)
+        {
+            try
+            {
+                new WebClient().DownloadString(url);
+            }
+            catch (WebException e)
+            {
+                var response = e.Response as HttpWebResponse;
+                if (response != null && response.StatusCode == HttpStatusCode.ProxyAuthenticationRequired)
+                {
+                    return false;
+                }
+            }
+            
+            return true;
+        }
+
+        private static void InitialiseProxyAuth()
+        {
+            Console.WriteLine("Proxy authentication required:");
+            
+            Console.Write("Username: ");
+            var username = Console.ReadLine();
+
+            Console.Write("Password: ");
+            var password = GetPassword();
+            Console.WriteLine();
+            Console.WriteLine();
+            
+            var credentials = new NetworkCredential(username, password);
+
+            WebRequest.DefaultWebProxy.Credentials = credentials;
+        }
+
+        /// <summary>
+        /// Get a password from the console
+        /// </summary>
+        /// <returns>Password stored in a SecureString</returns>
+        private static SecureString GetPassword()
+        {
+            var password = new SecureString();
+            while (true)
+            {
+                var keyInfo = Console.ReadKey(true);
+                if (keyInfo.Key == ConsoleKey.Enter)
+                {
+                    break;
+                }
+                
+                if (keyInfo.Key == ConsoleKey.Backspace)
+                {
+                    if (password.Length > 0)
+                    {
+                        password.RemoveAt(password.Length - 1);
+                        Console.Write("\b \b");
+                    }
+                }
+                else
+                {
+                    password.AppendChar(keyInfo.KeyChar);
+                    Console.Write("*");
+                }
+            }
+            return password;
+        }
+    }
+}

--- a/src/HtmlGenerator/Utilities/WebProxyAuthenticator.cs
+++ b/src/HtmlGenerator/Utilities/WebProxyAuthenticator.cs
@@ -11,6 +11,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Utilities
     public class WebProxyAuthenticator
     {
 
+        private static bool hasAuthenticated = false;
+
         /// <summary>
         /// Determine if there is a proxy that requires credentials.
         /// If there is, ask the user for the credentials and apply them to WebRequest.DefaultWebProxy
@@ -26,6 +28,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Utilities
 
         private static bool ProxyAuthSuccess(string url)
         {
+            if (hasAuthenticated)
+            {
+                return true;
+            }
+
             try
             {
                 new WebClient().DownloadString(url);
@@ -38,7 +45,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator.Utilities
                     return false;
                 }
             }
-            
+
+            hasAuthenticated = true;
             return true;
         }
 


### PR DESCRIPTION
The current version fails to run if the user is behind a proxy which requires authentication. I've added a class which will test if proxy authentication is required. If it detects that auth is required it will request the credentials from the user and apply them to WebRequest.DefaultWebProxy.