### PR TITLE
Make README.md clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Now also available on NuGet:
  2. Set HtmlGenerator project as startup and hit F5 - it is preconfigured to generate a website for TestCode\TestSolution.sln
  3. Pass a path to an .sln file or a .csproj file (or multiple paths separated by spaces) to create an index for them
  4. Pass /out:<path> to HtmlGenerator.exe to configure where to generate the website to. This path will be used in step 5 as your "physicalPath".
- 5. Edit .vs\config\applicationhost.config line 166 so that physicalPath points to \<virtualDirectory path="/" physicalPath="{Path from step 4}" />. Then you can set SourceIndexServer project as startup and run/debug the website.
+ 5. Edit .vs\config\applicationhost.config line 166 so that physicalPath points to \<virtualDirectory path="/" physicalPath="{PathFromStep4}" />. Then you can set SourceIndexServer project as startup and run/debug the website.
 
 ##Conceptual design
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Now also available on NuGet:
  1. Open SourceBrowser.sln.
  2. Set HtmlGenerator project as startup and hit F5 - it is preconfigured to generate a website for TestCode\TestSolution.sln
  3. Pass a path to an .sln file or a .csproj file (or multiple paths separated by spaces) to create an index for them
- 4. pass /out:<path> to HtmlGenerator.exe to configure where to generate the website to
- 5. Edit .vs\config\applicationhost.config line 166 so that physicalPath points to \<virtualDirectory path="/" physicalPath="C:\SourceBrowser\bin\debug\HtmlGenerator\Index" />. Then you can set SourceIndexServer project as startup and run/debug the website.
+ 4. Pass /out:<path> to HtmlGenerator.exe to configure where to generate the website to. This path will be used in step 5 as your "physicalPath".
+ 5. Edit .vs\config\applicationhost.config line 166 so that physicalPath points to \<virtualDirectory path="/" physicalPath="{Path from step 4}" />. Then you can set SourceIndexServer project as startup and run/debug the website.
 
 ##Conceptual design
 


### PR DESCRIPTION
As I was going through the steps to create the SourceBrowser for my own project, I was having difficulty understanding which physical path should actually be given the "SourceIndexServer". This PR is an attempt to make that a bit clearer to the end-users.