### PR TITLE
Added a temporary fix for multi project solutions

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -368,10 +368,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 return true;
             }
 
-            return solution.Projects.Any(
-                p => StringComparer.OrdinalIgnoreCase.Equals(
-                    p.AssemblyName,
-                    assemblyName));
+			bool inSolution = solution.Projects.Any(
+				p => StringComparer.OrdinalIgnoreCase.Equals(
+					p.AssemblyName,
+					assemblyName));
+
+	        return inSolution || Directory.Exists( Path.Combine( this.SolutionDestinationFolder, assemblyName ) );
         }
 
         public int GetExternalAssemblyIndex(string assemblyName)


### PR DESCRIPTION
I believe this could fix an issue presented in #6 

The issue that I experienced is that for projects that reference assemblies rather than a project the symbols created in a project that references the assembly will not create links to the implementation and will not show as a reference.

What I've done is to check to see if we've processed the assembly, if we have then assume it is part of the solution. This is unfortunately just a quick fix and assumes that the list of projects you are generating (if they are referencing an assembly) are generated in their proper build order.