### PR TITLE
Memoryfix

### DIFF
--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Utilities\Markup.cs" />
     <Compile Include="Utilities\MetadataReading.cs" />
     <Compile Include="Utilities\MSBuildExpressionParser.cs" />
+    <Compile Include="Utilities\MSBuildHelper.cs" />
     <Compile Include="Utilities\Paths.cs" />
     <Compile Include="Utilities\Reference.cs" />
     <Compile Include="Utilities\Serialization.cs" />

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -46,6 +46,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     {
                         Log.Write("Invalid argument: " + arg, ConsoleColor.Red);
                     }
+                    continue;
                 }
 
                 try
@@ -142,6 +143,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         solutionGenerator.Generate(solutionExplorerRoot: mergedSolutionExplorerRoot);
                     }
                 }
+                GC.Collect();
             }
         }
 

--- a/src/HtmlGenerator/Utilities/MSBuildHelper.cs
+++ b/src/HtmlGenerator/Utilities/MSBuildHelper.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.SourceBrowser.HtmlGenerator.Utilities
+{
+    public static class MSBuildHelper
+    {
+        private static string GetAssemblyFromProject(string projFile)
+        {
+            using (ProjectCollection p = new ProjectCollection())
+            {
+                var sln = p.LoadProject(projFile);
+                string output = sln.GetPropertyValue("AssemblyName");
+
+                p.UnloadAllProjects();
+                ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+
+                return output;
+            }
+        }
+        public static IEnumerable<string> GetAssemblies(string path)
+        {
+            if (String.IsNullOrWhiteSpace(path))
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            if (path.EndsWith(".csproj") || path.EndsWith(".vbproj"))
+            {
+                try
+                {
+                    return new[] { GetAssemblyFromProject(path) };
+                }
+                catch
+                {
+                }
+                return Enumerable.Empty<string>();
+            }
+
+            if (path.EndsWith(".sln"))
+            {
+                var s = Microsoft.Build.Construction.SolutionFile.Parse(path);
+                List<string> assemblies = new List<string>(s.ProjectsInOrder.Count);
+                foreach (var proj in s.ProjectsInOrder)
+                {
+                    if (proj.ProjectType == SolutionProjectType.SolutionFolder)
+                    {
+                        continue;
+                    }
+                    try
+                    {
+                        string assembly = GetAssemblyFromProject(proj.AbsolutePath);
+                        assemblies.Add(assembly);
+                    }
+                    catch
+                    {
+                    }
+                }
+                return assemblies;
+            }
+
+            return Enumerable.Empty<string>();
+        }
+    }
+}


### PR DESCRIPTION
I have been running this against about 500 csproj files. However since we have been creating SolutionGenerators for each path coming in, this eventually causes an out of memory exception.

From what I can tell the culprit is the MSBuild: XmlDocumentWithLocation from the ProjectStringCache. However I don't think Roslyn gives a way to clean this cache up, so the fix I came up with was to use MSBuild to grab the assembly name then unload the projects. Although slightly slower it no longer causes the out of memory exception.