### PR TITLE
Set tab-size for code to 4

### DIFF
--- a/src/SourceIndexServer/styles.css
+++ b/src/SourceIndexServer/styles.css
@@ -21,6 +21,7 @@ pre {
     font-family: Consolas, 'Courier New', 'Andale Mono', 'Lucida Console', monospace;
     font-size: 12pt;
     line-height: 125%;
+    tab-size: 4;
 }
 
     pre a:focus {


### PR DESCRIPTION
We have some code formatted using tabs, which are defaulting to 8 spaces.  This changes the CSS to specify a tab-size of 4 for pre tags (for browsers that support it).