### PR TITLE
Fixed crash in FirstChanceExceptionHandler for MSBuild error when using relative output path

### DIFF
--- a/src/Common/Log.cs
+++ b/src/Common/Log.cs
@@ -11,8 +11,8 @@ namespace Microsoft.SourceBrowser.Common
         public const string MessageLogFile = "Messages.txt";
         private const string SeparatorBar = "===============================================";
 
-        public static string ErrorLogFilePath = ErrorLogFile;
-        public static string MessageLogFilePath = MessageLogFile;
+        private static string errorLogFilePath = Path.GetFullPath(ErrorLogFile);
+        private static string messageLogFilePath = Path.GetFullPath(MessageLogFile);
 
         public static void Exception(Exception e, string message, bool isSevere = true)
         {
@@ -52,6 +52,28 @@ namespace Microsoft.SourceBrowser.Common
                 {
                     Console.ForegroundColor = ConsoleColor.Gray;
                 }
+            }
+        }
+
+        public static string ErrorLogFilePath
+        {
+            get { return errorLogFilePath; }
+            set
+            {
+                if (!Path.IsPathRooted(value))
+                    throw new ArgumentException($"Path '{value}' is not rooted.", nameof(value));
+                errorLogFilePath = value;
+            }
+        }
+
+        public static string MessageLogFilePath
+        {
+            get { return messageLogFilePath; }
+            set
+            {
+                if (!Path.IsPathRooted(value))
+                    throw new ArgumentException($"Path '{value}' is not rooted.", nameof(value));
+                messageLogFilePath = value;
             }
         }
     }

--- a/src/Common/Log.cs
+++ b/src/Common/Log.cs
@@ -36,7 +36,14 @@ namespace Microsoft.SourceBrowser.Common
         {
             lock (consoleLock)
             {
-                File.AppendAllText(filePath, SeparatorBar + Environment.NewLine + message + Environment.NewLine, Encoding.UTF8);
+                try
+                {
+                    File.AppendAllText(filePath, SeparatorBar + Environment.NewLine + message + Environment.NewLine, Encoding.UTF8);
+                }
+                catch (Exception ex)
+                {
+                    Write($"Failed to write to ${filePath}: ${ex}.", ConsoleColor.Red);
+                }
             }
         }
 
@@ -58,23 +65,13 @@ namespace Microsoft.SourceBrowser.Common
         public static string ErrorLogFilePath
         {
             get { return errorLogFilePath; }
-            set
-            {
-                if (!Path.IsPathRooted(value))
-                    throw new ArgumentException($"Path '{value}' is not rooted.", nameof(value));
-                errorLogFilePath = value;
-            }
+            set { errorLogFilePath = value.MustBeAbsolute(); }
         }
 
         public static string MessageLogFilePath
         {
             get { return messageLogFilePath; }
-            set
-            {
-                if (!Path.IsPathRooted(value))
-                    throw new ArgumentException($"Path '{value}' is not rooted.", nameof(value));
-                messageLogFilePath = value;
-            }
+            set { messageLogFilePath = value.MustBeAbsolute(); }
         }
     }
 }

--- a/src/Common/Paths.cs
+++ b/src/Common/Paths.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace Microsoft.SourceBrowser.Common
@@ -31,6 +32,15 @@ namespace Microsoft.SourceBrowser.Common
             }
 
             return path.TrimEnd('\\');
+        }
+
+        public static string MustBeAbsolute(this string path)
+        {
+            if (!Path.IsPathRooted(path))
+            {
+                throw new ArgumentException($"Path '{path}' is not absolute.", nameof(path));
+            }
+            return path;
         }
     }
 }

--- a/src/HtmlGenerator/Pass1-Generation/GenerateFromBuildLog.cs
+++ b/src/HtmlGenerator/Pass1-Generation/GenerateFromBuildLog.cs
@@ -48,7 +48,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 {
                     Log.Write("TypeScript invocation", ConsoleColor.Magenta);
                     var typeScriptGenerator = new TypeScriptSupport();
-                    typeScriptGenerator.Generate(invocation.TypeScriptFiles);
+                    typeScriptGenerator.Generate(invocation.TypeScriptFiles, Paths.SolutionDestinationFolder);
                 }
                 else if (invocation.ProjectFilePath != "-")
                 {

--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -277,7 +277,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 }
             }
 
-            new TypeScriptSupport().Generate(typeScriptFiles);
+            new TypeScriptSupport().Generate(typeScriptFiles, SolutionDestinationFolder);
 
             if (currentBatch.Length > 1)
             {

--- a/src/HtmlGenerator/Pass1-Generation/TypeScriptSupport.cs
+++ b/src/HtmlGenerator/Pass1-Generation/TypeScriptSupport.cs
@@ -15,14 +15,15 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         private Dictionary<string, List<Reference>> references;
         private List<string> declarations;
         public Dictionary<string, List<Tuple<string, long>>> SymbolIDToListOfLocationsMap { get; private set; }
-        public static readonly string ProjectDestinationFolder = Path.Combine(Paths.SolutionDestinationFolder, Constants.TypeScriptFiles);
 
-        public void Generate(IEnumerable<string> typeScriptFiles)
+        public void Generate(IEnumerable<string> typeScriptFiles, string solutionDestinationFolder)
         {
             if (typeScriptFiles == null || !typeScriptFiles.Any())
             {
                 return;
             }
+
+            var projectDestinationFolder = Path.Combine(solutionDestinationFolder, Constants.TypeScriptFiles).MustBeAbsolute();
 
             declarations = new List<string>();
             references = new Dictionary<string, List<Reference>>(StringComparer.OrdinalIgnoreCase);
@@ -69,11 +70,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             declarations.Sort();
 
             Serialization.WriteDeclaredSymbols(
-                ProjectDestinationFolder,
+                projectDestinationFolder,
                 declarations);
 
             ProjectGenerator.GenerateSymbolIDToListOfDeclarationLocationsMap(
-                ProjectDestinationFolder,
+                projectDestinationFolder,
                 SymbolIDToListOfLocationsMap);
         }
 

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             {
                 if (arg.StartsWith("/out:"))
                 {
-                    Paths.SolutionDestinationFolder = arg.Substring("/out:".Length).StripQuotes();
+                    Paths.SolutionDestinationFolder = Path.GetFullPath(arg.Substring("/out:".Length).StripQuotes());
                     continue;
                 }
 
@@ -72,8 +72,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 Paths.SolutionDestinationFolder = Path.Combine(Microsoft.SourceBrowser.Common.Paths.BaseAppFolder, "Index");
             }
 
-            Log.ErrorLogFilePath = Path.GetFullPath(Path.Combine(Paths.SolutionDestinationFolder, Log.ErrorLogFile));
-            Log.MessageLogFilePath = Path.GetFullPath(Path.Combine(Paths.SolutionDestinationFolder, Log.MessageLogFile));
+            Log.ErrorLogFilePath = Path.Combine(Paths.SolutionDestinationFolder, Log.ErrorLogFile);
+            Log.MessageLogFilePath = Path.Combine(Paths.SolutionDestinationFolder, Log.MessageLogFile);
 
             // Warning, this will delete and recreate your destination folder
             Paths.PrepareDestinationFolder();

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -72,8 +72,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 Paths.SolutionDestinationFolder = Path.Combine(Microsoft.SourceBrowser.Common.Paths.BaseAppFolder, "Index");
             }
 
-            Log.ErrorLogFilePath = Path.Combine(Paths.SolutionDestinationFolder, Log.ErrorLogFile);
-            Log.MessageLogFilePath = Path.Combine(Paths.SolutionDestinationFolder, Log.MessageLogFile);
+            Log.ErrorLogFilePath = Path.GetFullPath(Path.Combine(Paths.SolutionDestinationFolder, Log.ErrorLogFile));
+            Log.MessageLogFilePath = Path.GetFullPath(Path.Combine(Paths.SolutionDestinationFolder, Log.MessageLogFile));
 
             // Warning, this will delete and recreate your destination folder
             Paths.PrepareDestinationFolder();

--- a/src/HtmlGenerator/Utilities/Paths.cs
+++ b/src/HtmlGenerator/Utilities/Paths.cs
@@ -11,7 +11,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 {
     public static class Paths
     {
-        public static string SolutionDestinationFolder = null;
+        private static string solutionDestinationFolder;
+        public static string SolutionDestinationFolder
+        {
+            get { return solutionDestinationFolder; }
+            set { solutionDestinationFolder = value.MustBeAbsolute(); }
+        }
 
         public static string ProcessedAssemblies
         {


### PR DESCRIPTION
### Problem

1. I used a relative path for an output directory, e.g. `/out:_index`.
2. One of the projects I was processing caused an MSBuild error, specifically:

        System.InvalidCastException: Unable to cast object of type 'Roxel.BuildTasks.EnsureBindingRedirects' to type 'Microsoft.Build.Framework.ITask'.
            at Microsoft.Build.Shared.TaskLoader.CreateTask(LoadedType loadedType, String taskName, String taskLocation, Int32 taskLine, Int32 taskColumn, LogError logError, AppDomainSetup appDomainSetup, Boolean isOutOfProc, AppDomain& taskAppDomain)

3. When `FirstChanceExceptionHandler.HandleFirstChanceException` was called, current directory was set to the directory of the project I was processing (probably by MSBuild)
4. That caused a crash since relative path `_index\Errors.txt` didn't exist under that directory.

        Unhandled Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\MySolution\MyProject\_index\Errors.txt'.
           at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
           at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
           at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
           at System.IO.StreamWriter.CreateFile(String path, Boolean append, Boolean checkHost)
           at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost)
           at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding)
           at System.IO.File.InternalAppendAllText(String path, String contents, Encoding encoding)
           at Microsoft.SourceBrowser.Common.Log.WriteToFile(String message, String filePath) in C:\Development\Symphony\Prototype\SourceBrowser\github\SourceBrowser\src\Common\Log.cs:line 39
           at Microsoft.SourceBrowser.Common.Log.Exception(String message, Boolean isSevere) in C:\Development\Symphony\Prototype\SourceBrowser\github\SourceBrowser\src\Common\Log.cs:line 26
           at Microsoft.SourceBrowser.Common.Log.Exception(Exception e, String message, Boolean isSevere) in C:\Development\Symphony\Prototype\SourceBrowser\github\SourceBrowser\src\Common\Log.cs:line 20
           at Microsoft.SourceBrowser.HtmlGenerator.FirstChanceExceptionHandler.HandleFirstChanceException(Object sender, FirstChanceExceptionEventArgs e) in C:\Development\Symphony\Prototype\SourceBrowser\github\SourceBrowser\src\HtmlGenerator\Utilities\FirstChanceExceptionHandler.cs:line 128

### Solution

I have added a `GetFullPath` call to make sure paths are absolute as per initial current directory, and a check that insures non-absolute paths would not be used.

### Questions

Does this need tests, and what kind of tests would apply here?