### PR TITLE
Fixed build error when path to HtmlGenerator.csproj contains spaces

### DIFF
--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -1255,6 +1255,6 @@
     <NuGetInput Include="$(NuSpecFile)" />
   </ItemGroup>
   <Target Name="BuildNuGet" AfterTargets="CoreBuild" Condition="Exists('$(NuSpecFile)')" DependsOnTargets="CopyFilesToOutputDirectory" Inputs="@(NuGetInput)" Outputs="$(OutDir)\Microsoft.SourceBrowser.$(NuGetVersion).nupkg">
-    <Exec Command="$(SolutionDir)\.nuget\NuGet.exe Pack Microsoft.SourceBrowser.nuspec -NoPackageAnalysis -BasePath $(OutDir) -OutputDirectory $(OutDir) -prop currentVersion=$(NuGetVersion)" />
+    <Exec Command="&quot;$(SolutionDir)\.nuget\NuGet.exe&quot; Pack Microsoft.SourceBrowser.nuspec -NoPackageAnalysis -BasePath &quot;$(OutDir.TrimEnd('\'))&quot; -OutputDirectory &quot;$(OutDir.TrimEnd('\'))&quot; -prop currentVersion=$(NuGetVersion)" />
   </Target>
 </Project>


### PR DESCRIPTION
### Problem
SourceBrowser build fails (on nuget pack) if there are spaces in the full path to HtmlGenerator.csproj.

### Solution
Added quotes around dynamic paths in the MSBuild call to nuget pack.