### PR TITLE
New '/assemblylist' switch to emit assembly list instead of solution browser

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.ProjectExplorer.cs
+++ b/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.ProjectExplorer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -35,7 +36,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             sb.AppendLine("Declared&nbsp;symbols:&nbsp;" + this.DeclaredSymbols.Count.WithThousandSeparators() + "<br>");
             sb.AppendLine("Declared&nbsp;types:&nbsp;" + namedTypes.Count().WithThousandSeparators() + "<br>");
             sb.AppendLine("Public&nbsp;types:&nbsp;" + namedTypes.Where(t => t.DeclaredAccessibility == Accessibility.Public).Count().WithThousandSeparators() + "<br>");
-            sb.AppendLine("Indexed&nbsp;on:&nbsp;" + DateTime.Now.ToString("MMMM dd"));
+            sb.AppendLine("Indexed&nbsp;on:&nbsp;" + DateTime.Now.ToString("MMMM dd", CultureInfo.InvariantCulture));
 
             sb.AppendLine("</p>");
         }

--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -289,57 +289,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             return currentBatch.Length < projectsToProcess.Length;
         }
 
-        public void GenerateResultsHtml(IEnumerable<string> assemblyList)
-        {
-            var sb = new StringBuilder();
-            var sorter = GetCustomRootSorter();
-            var assemblyNames = assemblyList.ToList();
-            assemblyNames.Sort(sorter);
-
-            sb.AppendLine(Markup.GetResultsHtmlPrefix());
-
-            //foreach (var assemblyName in assemblyNames)
-            //{
-            //    sb.AppendFormat(@"<a href=""/#{0},namespaces"" target=""_top""><div class=""resultItem""><div class=""resultLine"">{0}</div></div></a>", assemblyName);
-            //    sb.AppendLine();
-            //}
-
-            sb.AppendLine(Markup.GetResultsHtmlSuffix());
-
-            File.WriteAllText(Path.Combine(SolutionDestinationFolder, "results.html"), sb.ToString());
-        }
-
-        public Comparison<string> GetCustomRootSorter()
-        {
-            var file = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                "AssemblySortOrder.txt");
-            if (!File.Exists(file))
-            {
-                return (l, r) => StringComparer.OrdinalIgnoreCase.Compare(l, r);
-            }
-
-            var lines = File
-                .ReadAllLines(file)
-                .Select((assemblyName, index) => new KeyValuePair<string, int>(assemblyName, index + 1))
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-            return (l, r) =>
-            {
-                int index1, index2;
-                lines.TryGetValue(l, out index1);
-                lines.TryGetValue(r, out index2);
-                if (index1 == 0 || index2 == 0)
-                {
-                    return l.CompareTo(r);
-                }
-                else
-                {
-                    return index1 - index2;
-                }
-            };
-        }
-
         private void SetFieldValue(object instance, string fieldName, object value)
         {
             var type = instance.GetType();

--- a/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.cs
+++ b/src/HtmlGenerator/Pass2-Finalization/SolutionFinalizer.cs
@@ -101,8 +101,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             if (emitAssemblyList)
             {
+                var assemblyNames = projects
+                    .Where(projectFinalizer => projectFinalizer.ProjectInfoLine != null)
+                    .Select(projectFinalizer => projectFinalizer.AssemblyId).ToList();
+
                 var sorter = GetCustomRootSorter();
-                var assemblyNames = assemblyNameToProjectMap.Keys.ToList();
                 assemblyNames.Sort(sorter);
 
                 Markup.GenerateResultsHtmlWithAssemblyList(SolutionDestinationFolder, assemblyNames);

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -136,7 +136,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private static void PrintUsage()
         {
-            Console.WriteLine(@"Usage: HtmlGenerator [/out:<outputdirectory>] <pathtosolution1.csproj|vbproj|sln> [more solutions/projects..] [/in:<filecontaingprojectlist>]");
+            Console.WriteLine(@"Usage: HtmlGenerator "
+                + @"[/out:<outputdirectory>] "
+                + @"<pathtosolution1.csproj|vbproj|sln> [more solutions/projects..] "
+                + @"[/in:<filecontaingprojectlist>] "
+                + @"[/assemblylist]");
         }
 
         private static readonly Folder<Project> mergedSolutionExplorerRoot = new Folder<Project>();

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -70,6 +70,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 if (arg == "/assemblylist")
                 {
                     emitAssemblyList = true;
+                    continue;
                 }
 
                 try

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.SourceBrowser.Common;
 
@@ -20,6 +21,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             var projects = new List<string>();
             var properties = new Dictionary<string, string>();
+            var emitAssemblyList = false;
 
             foreach (var arg in args)
             {
@@ -65,6 +67,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     }
                 }
 
+                if (arg == "/assemblylist")
+                {
+                    emitAssemblyList = true;
+                }
+
                 try
                 {
                     AddProject(projects, arg);
@@ -98,7 +105,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             using (Disposable.Timing("Generating website"))
             {
                 IndexSolutions(projects, properties);
-                FinalizeProjects();
+                FinalizeProjects(emitAssemblyList);
             }
         }
 
@@ -171,7 +178,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             }
         }
 
-        private static void FinalizeProjects()
+        private static void FinalizeProjects(bool emitAssemblyList)
         {
             GenerateLooseFilesProject(Constants.MSBuildFiles, Paths.SolutionDestinationFolder);
             GenerateLooseFilesProject(Constants.TypeScriptFiles, Paths.SolutionDestinationFolder);
@@ -180,7 +187,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 try
                 {
                     var solutionFinalizer = new SolutionFinalizer(Paths.SolutionDestinationFolder);
-                    solutionFinalizer.FinalizeProjects(mergedSolutionExplorerRoot);
+                    solutionFinalizer.FinalizeProjects(emitAssemblyList, mergedSolutionExplorerRoot);
                 }
                 catch (Exception ex)
                 {

--- a/src/HtmlGenerator/Utilities/Markup.cs
+++ b/src/HtmlGenerator/Utilities/Markup.cs
@@ -302,15 +302,15 @@ Don't use this page directly, pass #symbolId to get redirected.
             var sb = new StringBuilder();
 
             sb.AppendLine(GetResultsHtmlPrefix());
-            sb.AppendLine(GetResultsHtmlSuffix());
-            sb.AppendLine("<script>useSolutionExplorer = false;</script>");
+            sb.AppendLine(GetResultsHtmlSuffix(emitSolutionBrowserLink: false));
 
             File.WriteAllText(Path.Combine(solutionDestinationFolder, "results.html"), sb.ToString());
         }
 
-        public static void GenerateResultsHtml(string solutionDestinationFolder, IEnumerable<string> assemblyList)
+        public static void GenerateResultsHtmlWithAssemblyList(string solutionDestinationFolder, IEnumerable<string> assemblyList)
         {
             var sb = new StringBuilder();
+
             sb.AppendLine(GetResultsHtmlPrefix());
 
             foreach (var assemblyName in assemblyList)
@@ -320,7 +320,7 @@ Don't use this page directly, pass #symbolId to get redirected.
                 sb.AppendLine();
             }
 
-            sb.AppendLine(GetResultsHtmlSuffix());
+            sb.AppendLine(GetResultsHtmlSuffix(emitSolutionBrowserLink: true));
 
             File.WriteAllText(Path.Combine(solutionDestinationFolder, "results.html"), sb.ToString());
         }
@@ -340,9 +340,13 @@ Enter a type or member name or <a href=""/#q=assembly%20"" target=""_top"" class
 ";
         }
 
-        public static string GetResultsHtmlSuffix()
+        public static string GetResultsHtmlSuffix(bool emitSolutionBrowserLink)
         {
-            return @"</div></div></body></html>";
+            var solutionExplorerLink = emitSolutionBrowserLink
+                ? @"<div class=""note"">Try also browsing the <a href=""solutionexplorer.html"" class=""blueLink"">solution explorer</a>.</div>"
+                : null;
+
+            return @"</div></div>" + solutionExplorerLink + @"</body></html>";
         }
 
         private static string partialTypeDisambiguationFileTemplate = @"<!DOCTYPE html>

--- a/src/HtmlGenerator/Utilities/Markup.cs
+++ b/src/HtmlGenerator/Utilities/Markup.cs
@@ -300,8 +300,28 @@ Don't use this page directly, pass #symbolId to get redirected.
         public static void GenerateResultsHtml(string solutionDestinationFolder)
         {
             var sb = new StringBuilder();
+
             sb.AppendLine(GetResultsHtmlPrefix());
             sb.AppendLine(GetResultsHtmlSuffix());
+            sb.AppendLine("<script>useSolutionExplorer = false;</script>");
+
+            File.WriteAllText(Path.Combine(solutionDestinationFolder, "results.html"), sb.ToString());
+        }
+
+        public static void GenerateResultsHtml(string solutionDestinationFolder, IEnumerable<string> assemblyList)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(GetResultsHtmlPrefix());
+
+            foreach (var assemblyName in assemblyList)
+            {
+                sb.AppendFormat(
+                  @"<a href=""/#{0},namespaces"" target=""_top""><div class=""resultItem""><div class=""resultLine"">{0}</div></div></a>", assemblyName);
+                sb.AppendLine();
+            }
+
+            sb.AppendLine(GetResultsHtmlSuffix());
+
             File.WriteAllText(Path.Combine(solutionDestinationFolder, "results.html"), sb.ToString());
         }
 

--- a/src/SourceIndexServer/scripts.js
+++ b/src/SourceIndexServer/scripts.js
@@ -1,6 +1,6 @@
 ﻿var currentSelection = null;
 var currentResult = null;
-var useSolutionExplorer = true;
+var useSolutionExplorer = /*USE_SOLUTION_EXPLORER*/true/*USE_SOLUTION_EXPLORER*/;
 var anchorSplitChar = ",";
 
 var externalUrlMap = [


### PR DESCRIPTION
Let's try one more time :) I've parametrized `scripts.js`, added solution browser link to the bottom of assembly list and fixed some small issues I've introduced :)

Also, one unrelated thing: I've changed the dates rendering to use invariant culture (my work machine has localized OS, so I noticed output like "Indexed on: января 05").