### PR TITLE
Solve threading issues with concurrent `GenerateDocument()`

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -111,12 +112,23 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     Directory.CreateDirectory(ProjectDestinationFolder);
                 }
 
-                var documents = Project.Documents
-                    .Where(IncludeDocument)
-                    .OrderByDescending(GetDocumentSortOrder);
+                var documents = Project.Documents.Where(IncludeDocument).ToList();
 
-                var tasks = documents.Select(d => Task.Run(() => GenerateDocument(d))).ToArray();
-                await Task.WhenAll(tasks);
+                var generationTasks = Partitioner.Create(documents)
+                    .GetPartitions(Environment.ProcessorCount)
+                    .Select(partition =>
+                        Task.Run(async () =>
+                        {
+                            using (partition)
+                            {
+                                while (partition.MoveNext())
+                                {
+                                  await GenerateDocument(partition.Current);
+                                }
+                            }
+                        }));
+
+                await Task.WhenAll(generationTasks);
 
                 foreach (var document in documents)
                 {
@@ -164,16 +176,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var symbols = this.DeclaredSymbols.Keys.OfType<INamedTypeSymbol>()
                 .Select(s => new DeclaredSymbolInfo(s, this.AssemblyName));
             NamespaceExplorer.WriteNamespaceExplorer(this.AssemblyName, symbols, ProjectDestinationFolder);
-        }
-
-        private int GetDocumentSortOrder(Document document)
-        {
-            if (File.Exists(document.FilePath))
-            {
-                return (int)new FileInfo(document.FilePath).Length;
-            }
-
-            return 0;
         }
 
         private Task GenerateDocument(Document document)


### PR DESCRIPTION
The problem is simple: with the code below, generating website took `11:12`:

```c#
var documents = Project.Documents
    .Where(IncludeDocument)
    .OrderByDescending(GetDocumentSortOrder);

var tasks = documents.Select(d => Task.Run(() => GenerateDocument(d))).ToArray();
await Task.WhenAll(tasks);
```

I noticed a lot of delays with zero CPU usage during website generation and profiler shows a lot of thread pool threads stuck in sync waits somewhere inside asynchronous file system read API, deep inside Roslyn's document model. I've replaced the code above with simple sequential async code and time reduces down to `7:17`, delays are gone:

```c#
var documents = Project.Documents.Where(IncludeDocument).ToList();

foreach (var document in documents)
{
    await GenerateDocument(document);
}
```

Uglifying generation a bit more (because of missing `Parallel.ForEachAsync()`) makes it run in parallel, limiting the number of consumers based on available degree of parallelism. This reduces time to `4:15`:

```c#
var documents = Project.Documents.Where(IncludeDocument).ToList();

var generationTasks = Partitioner.Create(documents)
    .GetPartitions(Environment.ProcessorCount)
    .Select(partition =>
        Task.Run(async () =>
        {
            using (partition)
            {
                while (partition.MoveNext())
                {
                  await GenerateDocument(partition.Current);
                }
            }
        }));

await Task.WhenAll(generationTasks);
```