### PR TITLE
Avoid use of `Document.Name` to generate target .html file path

### DIFF
--- a/src/HtmlGenerator/Utilities/Paths.cs
+++ b/src/HtmlGenerator/Utilities/Paths.cs
@@ -166,7 +166,9 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string result = Path.Combine(document.Folders
                 .Select(SanitizeFolder)
                 .ToArray());
-            result = Path.Combine(result, document.Name);
+
+            result = Path.Combine(result, Path.GetFileName(document.FilePath));
+
             return result;
         }
 


### PR DESCRIPTION
I have a weird issue when generating site from some of the R# projects: for some reason, sometimes projects have all the `Document`s with the same `TextDocument.Name` value and I was unable to understand where it came from. Equal `Name` breaks site generation, since all the files with the same folder starts sharing the same target file path, producing tons of "File is already used by another process" IO exceptions.

For example, our C# support core project `Psi.CSharp.csproj` has all the documents names equal to `"CSharp"` and our Protobuf definiton file format support project `Psi.Protobuf.csproj` has all the documents with weird `"Impl"` as a name. And there is no a single mention of `Impl` everywhere in `Psi.Protobuf.csproj` or somewhere close.

I guess this may be the `MSBuildWorkspace` issue or something. I was unable to find suspicious sources of `TextDocument.Name` values in Roslyn's source code...

In this PR I've replaced usage of `TextDocument.Name` with `TextDocument.FilePath` property, by getting file name from full path - this feels more "reliable" (`TextDocument.Name` semantic is a bit unclear for me) and solves the generation issue on my solution.