### PR TITLE
Offline and no-console support

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/Federation.cs
+++ b/src/HtmlGenerator/Pass1-Generation/Federation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 
@@ -9,7 +10,28 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
     {
         public static IEnumerable<string> FederatedIndexUrls = new[] { @"http://referencesource.microsoft.com", @"http://source.roslyn.io" };
 
-        private List<HashSet<string>> assemblies = new List<HashSet<string>>();
+        private class Info
+        {
+            public Info(string server, HashSet<string> assemblies)
+            {
+                if (server == null) throw new ArgumentNullException(nameof(server));
+                if (assemblies == null) throw new ArgumentNullException(nameof(assemblies));
+
+                if (!server.StartsWith("http://"))
+                    server = "http://" + server;
+
+                if (!server.EndsWith("/"))
+                    server += "/";
+
+                Server = server;
+                Assemblies = assemblies;
+            }
+
+            public string Server { get; }
+            public HashSet<string> Assemblies { get; }
+        }
+
+        private readonly List<Info> federations = new List<Info>();
 
         public Federation() : this(FederatedIndexUrls)
         {
@@ -28,15 +50,31 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             foreach (var server in servers)
             {
-                var url = this.GetAssemblyUrl(server);
+                AddFederation(server);
+            }
+        }
 
-                var assemblyList = new WebClient().DownloadString(url);
-                var assemblyNames = new HashSet<string>(assemblyList
+        public void AddFederation(string server)
+        {
+            var url = GetAssemblyUrl(server);
+
+            var assemblyList = new WebClient().DownloadString(url);
+            var assemblyNames = GetAssemblyNames(assemblyList);
+
+            federations.Add(new Info(server, assemblyNames));
+        }
+
+        public void AddFederation(string server, string assemblyListFile)
+        {
+            federations.Add(new Info(server, GetAssemblyNames(File.ReadAllText(assemblyListFile))));
+        }
+
+        private HashSet<string> GetAssemblyNames(string assemblyList)
+        {
+            var assemblyNames = new HashSet<string>(assemblyList
                     .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(line => line.Split(';')[0]), StringComparer.OrdinalIgnoreCase);
-
-                assemblies.Add(assemblyNames);
-            }
+            return assemblyNames;
         }
 
         private string GetAssemblyUrl(string server)
@@ -54,15 +92,25 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         public int GetExternalAssemblyIndex(string assemblyName)
         {
-            for (int i = 0; i < assemblies.Count; i++)
+            // Order must match order in GetServers().
+            for (int i = 0; i < federations.Count; i++)
             {
-                if (assemblies[i].Contains(assemblyName))
+                if (federations[i].Assemblies.Contains(assemblyName))
                 {
                     return i;
                 }
             }
 
             return -1;
+        }
+
+        public IEnumerable<string> GetServers()
+        {
+            // Order must match order in GetExternalAssemblyIndex().
+            for (int i = 0; i < federations.Count; i++)
+            {
+                yield return federations[i].Server;
+            }
         }
     }
 }

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -22,12 +22,22 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var projects = new List<string>();
             var properties = new Dictionary<string, string>();
             var emitAssemblyList = false;
+            var force = false;
+            var noBuiltInFederations = false;
+            var offlineFederations = new Dictionary<string, string>();
+            var federations = new HashSet<string>();
 
             foreach (var arg in args)
             {
                 if (arg.StartsWith("/out:"))
                 {
                     Paths.SolutionDestinationFolder = Path.GetFullPath(arg.Substring("/out:".Length).StripQuotes());
+                    continue;
+                }
+
+                if (arg == "/force")
+                {
+                    force = true;
                     continue;
                 }
 
@@ -73,6 +83,33 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     continue;
                 }
 
+                if (arg == "/nobuiltinfederations")
+                {
+                    noBuiltInFederations = true;
+                    Log.Message("Disabling built-in federations.");
+                    continue;
+                }
+
+                if (arg.StartsWith("/federation:"))
+                {
+                    string server = arg.Substring("/federation:".Length);
+                    Log.Message($"Adding federation '{server}'.");
+                    federations.Add(server);
+                }
+
+                if (arg.StartsWith("/offlinefederation:"))
+                {
+                    var match = Regex.Match(arg, "/offlinefederation:(?<server>[^=]+)=(?<file>.+)");
+                    if (match.Success)
+                    {
+                        var server = match.Groups["server"].Value;
+                        var assemblyListFileName = match.Groups["file"].Value;
+                        offlineFederations[server] = assemblyListFileName;
+                        Log.Message($"Adding federation '{server}' (offline from '{assemblyListFileName}').");
+                        continue;
+                    }
+                }
+
                 try
                 {
                     AddProject(projects, arg);
@@ -101,12 +138,18 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             Log.MessageLogFilePath = Path.Combine(Paths.SolutionDestinationFolder, Log.MessageLogFile);
 
             // Warning, this will delete and recreate your destination folder
-            Paths.PrepareDestinationFolder();
+            Paths.PrepareDestinationFolder(force);
 
             using (Disposable.Timing("Generating website"))
             {
-                IndexSolutions(projects, properties);
-                FinalizeProjects(emitAssemblyList);
+                var federation = noBuiltInFederations ? new Federation(null) : new Federation();
+                foreach (var entry in offlineFederations)
+                {
+                    federation.AddFederation(entry.Key, entry.Value);
+                }
+
+                IndexSolutions(projects, properties, federation);
+                FinalizeProjects(emitAssemblyList, federation);
             }
         }
 
@@ -139,14 +182,17 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         {
             Console.WriteLine(@"Usage: HtmlGenerator "
                 + @"[/out:<outputdirectory>] "
+                + @"[/force] "
                 + @"<pathtosolution1.csproj|vbproj|sln> [more solutions/projects..] "
                 + @"[/in:<filecontaingprojectlist>] "
+                + @"[/nobuiltinfederations] "
+                + @"[/offlinefederation:server=assemblyListFile] "
                 + @"[/assemblylist]");
         }
 
         private static readonly Folder<Project> mergedSolutionExplorerRoot = new Folder<Project>();
 
-        private static void IndexSolutions(IEnumerable<string> solutionFilePaths, Dictionary<string, string> properties)
+        private static void IndexSolutions(IEnumerable<string> solutionFilePaths, Dictionary<string, string> properties, Federation federation)
         {
             var assemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -161,7 +207,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 }
             }
 
-            var federation = new Federation();
             foreach (var path in solutionFilePaths)
             {
                 using (Disposable.Timing("Generating " + path))
@@ -183,7 +228,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             }
         }
 
-        private static void FinalizeProjects(bool emitAssemblyList)
+        private static void FinalizeProjects(bool emitAssemblyList, Federation federation)
         {
             GenerateLooseFilesProject(Constants.MSBuildFiles, Paths.SolutionDestinationFolder);
             GenerateLooseFilesProject(Constants.TypeScriptFiles, Paths.SolutionDestinationFolder);
@@ -192,7 +237,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 try
                 {
                     var solutionFinalizer = new SolutionFinalizer(Paths.SolutionDestinationFolder);
-                    solutionFinalizer.FinalizeProjects(emitAssemblyList, mergedSolutionExplorerRoot);
+                    solutionFinalizer.FinalizeProjects(emitAssemblyList, federation, mergedSolutionExplorerRoot);
                 }
                 catch (Exception ex)
                 {

--- a/src/HtmlGenerator/Utilities/Paths.cs
+++ b/src/HtmlGenerator/Utilities/Paths.cs
@@ -55,7 +55,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             }
         }
 
-        public static void PrepareDestinationFolder()
+        public static void PrepareDestinationFolder(bool forceOverwrite = false)
         {
             if (!Configuration.CreateFoldersOnDisk &&
                 !Configuration.WriteDocumentsToDisk &&
@@ -66,27 +66,30 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             if (Directory.Exists(SolutionDestinationFolder))
             {
-                Log.Write(string.Format("Warning, {0} will be deleted! Are you sure? (y/n)", SolutionDestinationFolder), ConsoleColor.Red);
-                if (Console.ReadKey().KeyChar != 'y')
+                if (!forceOverwrite)
                 {
-                    if (!File.Exists(Paths.ProcessedAssemblies))
-                    {
-                        Environment.Exit(0);
-                    }
-
-                    Log.Write("Would you like to continue previously aborted index operation where it left off?", ConsoleColor.Green);
+                    Log.Write(string.Format("Warning, {0} will be deleted! Are you sure? (y/n)", SolutionDestinationFolder), ConsoleColor.Red);
                     if (Console.ReadKey().KeyChar != 'y')
                     {
-                        Environment.Exit(0);
+                        if (!File.Exists(Paths.ProcessedAssemblies))
+                        {
+                            Environment.Exit(0);
+                        }
+
+                        Log.Write("Would you like to continue previously aborted index operation where it left off?", ConsoleColor.Green);
+                        if (Console.ReadKey().KeyChar != 'y')
+                        {
+                            Environment.Exit(0);
+                        }
+                        else
+                        {
+                            return;
+                        }
                     }
                     else
                     {
-                        return;
+                        Console.WriteLine();
                     }
-                }
-                else
-                {
-                    Console.WriteLine();
                 }
 
                 Log.Write("Deleting " + SolutionDestinationFolder);

--- a/src/SourceIndexServer/scripts.js
+++ b/src/SourceIndexServer/scripts.js
@@ -4,8 +4,7 @@ var useSolutionExplorer = /*USE_SOLUTION_EXPLORER*/true/*USE_SOLUTION_EXPLORER*/
 var anchorSplitChar = ",";
 
 var externalUrlMap = [
-    "http://referencesource.microsoft.com/",
-    "http://source.roslyn.io/"
+    /*EXTERNAL_URL_MAP*/"http://referencesource.microsoft.com/","http://source.roslyn.io/"/*EXTERNAL_URL_MAP*/
 ];
 
 var supportedFileExtensions = [


### PR DESCRIPTION
Hi,

this PR contains two (sorry about that) changes:

1.) Adds a "/force" command line option that prevents interactive asking about whether an existing directory should be deleted and just does so. (Useful for build servers, etc. where there is no stdin).

2.) Adds the following options to handle federations:

   **/nobuiltinfederations**                 Disables the built-in federations and thus effectively turns the
                                                    processing to "offline". Our build servers, for example, don't
                                                    have internet access. Of course, links to .NET and Roslyn are
                                                    not generated that way.


   **/offlinefederation:server=filename**
                                                    This mitigates the above, basically you can manually download
                                                    the Assemblies.txt file from, say, sourcesof.net and then pass
                                                    the following:

   `/offlinefederation:http://referencesource.microsoft.com/=<path to file>`

   **/federation:server**                      This is just for completeness. Basically it works online (as the builtins
                                                    would, but lets you specify alternate URLs/servers.

Cheers,
Christian
                                                 




