### PR TITLE
Add flag to improve performance

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -92,7 +92,9 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             propertiesOpt = propertiesOpt.Add("CheckForSystemRuntimeDependency", "true");
             propertiesOpt = propertiesOpt.Add("VisualStudioVersion", "14.0");
 
-            return MSBuildWorkspace.Create(properties: propertiesOpt, hostServices: WorkspaceHacks.Pack);
+            var w = MSBuildWorkspace.Create(properties: propertiesOpt, hostServices: WorkspaceHacks.Pack);
+            w.LoadMetadataForReferencedProjects = true;
+            return w;
         }
 
         private static Solution CreateSolution(


### PR DESCRIPTION
In some cases (with a large network of project references), loading a project into a workspace can take an inordinate amount of time. Setting this flag (when a build has already taken place) ameliorates this problem.