### PR TITLE
Fix federation support

### DIFF
--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -94,6 +94,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     string server = arg.Substring("/federation:".Length);
                     Log.Message($"Adding federation '{server}'.");
                     federations.Add(server);
+                    continue;
                 }
 
                 if (arg.StartsWith("/offlinefederation:"))
@@ -107,6 +108,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         Log.Message($"Adding federation '{server}' (offline from '{assemblyListFileName}').");
                         continue;
                     }
+                    
+                    continue;
                 }
 
                 try


### PR DESCRIPTION
Federation support is currently broken, as it tries to add the federated url to the projects path as well.

With these changes federation works as expected.

Example:

    /federation:http://referencesource.microsoft.com

This will now properly link to Microsoft Reference Source.