### PR TITLE
Fix namespace on MEF project.

### DIFF
--- a/src/GitGlyph/GitBlameVisitor.cs
+++ b/src/GitGlyph/GitBlameVisitor.cs
@@ -3,16 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using LibGit2Sharp;
+using Microsoft.SourceBrowser.MEF;
 
 namespace GitGlyph
 {
-    public class GitBlameVisitor : MEF.ITextVisitor
+    public class GitBlameVisitor : ITextVisitor
     {
         private Repository Repository { get; set; }
         private string Root { get; set; }
-        private MEF.ILog Logger { get; set; }
+        private ILog Logger { get; set; }
 
-        public GitBlameVisitor(Repository r, MEF.ILog logger)
+        public GitBlameVisitor(Repository r, ILog logger)
         {
             Repository = r;
             Logger = logger;
@@ -21,8 +22,8 @@ namespace GitGlyph
 
         public string Visit(string text, IReadOnlyDictionary<string, string> context)
         {
-            var path = System.IO.Path.GetFullPath(context[MEF.ContextKeys.FilePath]);
-            var blame = GetBlame(path).FirstOrDefault(bh => bh.FinalStartLineNumber.ToString() == context[MEF.ContextKeys.LineNumber]);
+            var path = System.IO.Path.GetFullPath(context[ContextKeys.FilePath]);
+            var blame = GetBlame(path).FirstOrDefault(bh => bh.FinalStartLineNumber.ToString() == context[ContextKeys.LineNumber]);
 
             if (blame != null)
             {
@@ -39,7 +40,7 @@ namespace GitGlyph
 
         private string FormatContext(IReadOnlyDictionary<string, string> context)
         {
-            return string.Format("File: {0}\nLine: {1}", MakeRelativeToRepository(context[MEF.ContextKeys.FilePath]), context[MEF.ContextKeys.LineNumber]);
+            return string.Format("File: {0}\nLine: {1}", MakeRelativeToRepository(context[ContextKeys.FilePath]), context[ContextKeys.LineNumber]);
         }
 
         private string ShortenObjectId(GitObject o)

--- a/src/GitGlyph/GitSourceBrowserPlugin.cs
+++ b/src/GitGlyph/GitSourceBrowserPlugin.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using LibGit2Sharp;
-using MEF;
+using Microsoft.SourceBrowser.MEF;
 
 namespace GitGlyph
 {

--- a/src/MEF/ContextKeys.cs
+++ b/src/MEF/ContextKeys.cs
@@ -1,4 +1,4 @@
-﻿namespace MEF
+﻿namespace Microsoft.SourceBrowser.MEF
 {
     public static class ContextKeys
     {

--- a/src/MEF/ILog.cs
+++ b/src/MEF/ILog.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MEF
+namespace Microsoft.SourceBrowser.MEF
 {
     public interface ILog
     {

--- a/src/MEF/ISourceBrowserPlugin.cs
+++ b/src/MEF/ISourceBrowserPlugin.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace MEF
+namespace Microsoft.SourceBrowser.MEF
 {
     public interface ISourceBrowserPlugin
     {

--- a/src/MEF/ISourceBrowserPluginMetadata.cs
+++ b/src/MEF/ISourceBrowserPluginMetadata.cs
@@ -1,4 +1,4 @@
-﻿namespace MEF
+﻿namespace Microsoft.SourceBrowser.MEF
 {
     public interface ISourceBrowserPluginMetadata
     {

--- a/src/MEF/ISymbolVisitor.cs
+++ b/src/MEF/ISymbolVisitor.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
-namespace MEF
+namespace Microsoft.SourceBrowser.MEF
 {
     public interface ISymbolVisitor
     {

--- a/src/MEF/ITextVisitor.cs
+++ b/src/MEF/ITextVisitor.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace MEF
+namespace Microsoft.SourceBrowser.MEF
 {
     public interface ITextVisitor
     {

--- a/src/MEF/PluginAggregator.cs
+++ b/src/MEF/PluginAggregator.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
-namespace MEF
+namespace Microsoft.SourceBrowser.MEF
 {
     public class PluginAggregator : IReadOnlyDictionary<string, ISourceBrowserPlugin>, IDisposable
     {

--- a/src/MEF/SymbolVisitorWrapper.cs
+++ b/src/MEF/SymbolVisitorWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
-namespace MEF
+namespace Microsoft.SourceBrowser.MEF
 {
     public class SymbolVisitorWrapper : SymbolVisitor<string>
     {


### PR DESCRIPTION
Cleanups -- realized I hadn't properly namespaced the contracts library for MEF plugins.