### PR TITLE
Cleanups and fixes

### DIFF
--- a/src/GitGlyph/packages.config
+++ b/src/GitGlyph/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.2.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0" targetFramework="net46" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.30" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />

--- a/src/HtmlGenerator/packages.config
+++ b/src/HtmlGenerator/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.2.1" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.1" targetFramework="net46" />
@@ -18,8 +18,8 @@
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.1" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net46" />
   <package id="Microsoft.Language.Xml" version="1.0.9" targetFramework="net46" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />

--- a/src/MEF/packages.config
+++ b/src/MEF/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.2.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.0" targetFramework="net46" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.30" targetFramework="net46" />
   <package id="System.Collections" version="4.0.11" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.2.0" targetFramework="net46" />


### PR DESCRIPTION
Things I discovered while working on https://github.com/ddurschlag/BitBucketSourceBrowserPlugin . The git plugin can remain as an example in this repo; having an example is useful, and you probably use git if you use SourceBrowser (though you may want to remove the plugin for performance reasons on very large codebases, as git blame is quite slow). This plugin has no need to live in the same repo, and only makes sense if you use bitbucket.