### PR TITLE
Add support for server path prefix mappings

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -312,6 +312,14 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private string GetWebLink()
         {
+            var fullPath = Path.GetFullPath(Document.FilePath);
+            var serverPathMapping =
+                projectGenerator.SolutionGenerator.ServerPathMappings.FirstOrDefault(p => fullPath.StartsWith(p.Key));
+            if (serverPathMapping.Key != null)
+            {
+                return serverPathMapping.Value + fullPath.Substring(serverPathMapping.Key.Length).Replace('\\', '/');
+            }
+
             var serverPath = this.projectGenerator.SolutionGenerator.ServerPath;
             if (string.IsNullOrEmpty(serverPath))
             {

--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -17,6 +17,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         public string SolutionDestinationFolder { get; private set; }
         public string ProjectFilePath { get; private set; }
         public string ServerPath { get; set; }
+        public IReadOnlyDictionary<string, string> ServerPathMappings { get; }
         public string NetworkShare { get; private set; }
         private Federation Federation { get; set; }
         private readonly HashSet<string> typeScriptFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -35,12 +36,14 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string solutionDestinationFolder,
             string serverPath = null,
             ImmutableDictionary<string, string> properties = null,
-            Federation federation = null)
+            Federation federation = null,
+            IReadOnlyDictionary<string, string> serverPathMappings = null)
         {
             this.SolutionSourceFolder = Path.GetDirectoryName(solutionFilePath);
             this.SolutionDestinationFolder = solutionDestinationFolder;
             this.ProjectFilePath = solutionFilePath;
             this.ServerPath = serverPath;
+            ServerPathMappings = serverPathMappings;
             this.solution = CreateSolution(solutionFilePath, properties);
             this.Federation = federation ?? new Federation();
             SetupPluginAggregator();


### PR DESCRIPTION
This change adds support for defining server path mappings that identify a file system path prefix that maps to a url path.

This enables the "Server Path" links for github/gitlab repositories and any other hosting scheme that enables links like https://server.com/repo/path/to/file.txt