### PR TITLE
Merge plugin improvements

### DIFF
--- a/src/GitGlyph/GitBlameVisitor.cs
+++ b/src/GitGlyph/GitBlameVisitor.cs
@@ -85,7 +85,9 @@ namespace GitGlyph
                 {
                     if (path.StartsWith(Root))
                     {
-                        result = Repository.Blame(MakeRelativeToRepository(path));
+                        var relativePath = MakeRelativeToRepository(path);
+                        if (!Repository.Ignore.IsPathIgnored(relativePath))
+                            result = Repository.Blame(relativePath);
                     }
                     else
                     {
@@ -94,7 +96,7 @@ namespace GitGlyph
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error("Couldn't blame " + path, ex);
+                    Logger.Info("Couldn't blame " + path, ex);
                     result = new BlameHunk[0];
                 }
                 getBlameResultCache.Add(path, result);

--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -14,6 +14,14 @@
   </PropertyGroup>
   <Import Project="..\..\Common.props" />
   <ItemGroup>
+    <Reference Include="ExceptionAnalysis, Version=1.0.0.39796, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ExceptionAnalysis.Diagnostics.1.0.0.39796\lib\net46\ExceptionAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ExceptionAnalysis.Diagnostics, Version=1.0.0.39796, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ExceptionAnalysis.Diagnostics.1.0.0.39796\lib\net46\ExceptionAnalysis.Diagnostics.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Build, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Tasks.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -1259,7 +1267,9 @@
       <Link>Web\Web.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -26,6 +26,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var offlineFederations = new Dictionary<string, string>();
             var federations = new HashSet<string>();
             var serverPathMappings = new Dictionary<string, string>();
+            var pluginBlacklist = new List<string>();
 
             foreach (var arg in args)
             {
@@ -122,7 +123,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         Log.Message($"Adding federation '{server}' (offline from '{assemblyListFileName}').");
                         continue;
                     }
-                    
+                    continue;
+                }
+
+                if (arg.StartsWith("/noplugin:"))
+                {
+                    pluginBlacklist.Add(arg.Substring("/noplugin:".Length));
                     continue;
                 }
 
@@ -164,7 +170,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     federation.AddFederation(entry.Key, entry.Value);
                 }
 
-                IndexSolutions(projects, properties, federation, serverPathMappings);
+                IndexSolutions(projects, properties, federation, serverPathMappings, pluginBlacklist);
                 FinalizeProjects(emitAssemblyList, federation);
             }
         }
@@ -208,7 +214,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private static readonly Folder<Project> mergedSolutionExplorerRoot = new Folder<Project>();
 
-        private static void IndexSolutions(IEnumerable<string> solutionFilePaths, Dictionary<string, string> properties, Federation federation, Dictionary<string, string> serverPathMappings)
+        private static void IndexSolutions(IEnumerable<string> solutionFilePaths, Dictionary<string, string> properties, Federation federation, Dictionary<string, string> serverPathMappings, IEnumerable<string> pluginBlacklist)
         {
             var assemblyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -232,7 +238,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         Paths.SolutionDestinationFolder,
                         properties: properties.ToImmutableDictionary(),
                         federation: federation,
-                        serverPathMappings: serverPathMappings))
+                        serverPathMappings: serverPathMappings,
+                        pluginBlacklist: pluginBlacklist))
                     {
                         solutionGenerator.GlobalAssemblyList = assemblyNames;
                         solutionGenerator.Generate(solutionExplorerRoot: mergedSolutionExplorerRoot);

--- a/src/HtmlGenerator/packages.config
+++ b/src/HtmlGenerator/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ExceptionAnalysis.Diagnostics" version="1.0.0.39796" targetFramework="net46" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />

--- a/src/MEF/MEF.csproj
+++ b/src/MEF/MEF.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -91,6 +91,7 @@
     <Compile Include="ITextVisitor.cs" />
     <Compile Include="PluginAggregator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SourceBrowserPluginWrapper.cs" />
     <Compile Include="SymbolVisitorWrapper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MEF/SourceBrowserPluginWrapper.cs
+++ b/src/MEF/SourceBrowserPluginWrapper.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+
+namespace Microsoft.SourceBrowser.MEF
+{
+    /// <summary>
+    /// A wrapper around MEF-imported objects to prevent exceptions from bubbling up
+    /// </summary>
+    public class SourceBrowserPluginWrapper : ISourceBrowserPlugin, ISourceBrowserPluginMetadata
+    {
+        private ISourceBrowserPluginMetadata Metadata;
+        private ISourceBrowserPlugin Plugin;
+        private ILog Logger;
+
+        public SourceBrowserPluginWrapper(ISourceBrowserPlugin plugin, ISourceBrowserPluginMetadata metadata, ILog logger)
+        {
+            Plugin = plugin;
+            Metadata = metadata;
+            Logger = logger;
+        }
+
+        public string Name
+        {
+            get
+            {
+                try
+                {
+                    return Metadata.Name;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Info("Couldn't retrieve plugin name", ex);
+                    return "Unknown Plugin";
+                }
+            }
+        }
+
+        public void Init(Dictionary<string, string> configuration, ILog logger)
+        {
+            try
+            {
+                Plugin.Init(configuration, logger);
+            }
+            catch (Exception ex)
+            {
+                Logger.Info(Name + " plugin failed to initialize", ex);
+            }
+        }
+
+        public IEnumerable<ISymbolVisitor> ManufactureSymbolVisitors(string projectPath)
+        {
+            try
+            {
+                return Plugin.ManufactureSymbolVisitors(projectPath);
+            }
+            catch (Exception ex)
+            {
+                Logger.Info(Name + " plugin failed to manufacture symbol visitors", ex);
+                return Enumerable.Empty<ISymbolVisitor>();
+            }
+        }
+
+        public IEnumerable<ITextVisitor> ManufactureTextVisitors(string projectPath)
+        {
+            try
+            {
+                return Plugin.ManufactureTextVisitors(projectPath);
+            }
+            catch (Exception ex)
+            {
+                Logger.Info(Name + " plugin failed to manufacture text visitors", ex);
+                return Enumerable.Empty<ITextVisitor>();
+            }
+        }
+
+        public Module PluginModule
+        {
+            get
+            {
+                return Plugin.GetType().Module;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a few improvements (I know, I should have split them -- sorry).

1) The git plugin included by default is quieter.
2) The plugin code exposes a list of modules it has pulled plugins from. In combination with a small, separate nuget package I created for parsing up stack traces, this lets the first chance exception handler ignore all exceptions from plugins.
3) A plugin blacklist is maintained and can be passed in from the command line.
4) Exceptions will NEVER bubble out of plugins -- a thin wrapper is used to re-expose plugin functionality with try/catch/log wrapping. This is also on the quiet side of logging.

Further improvements may be possible, but this should be a good start.