### PR TITLE
Add ASP.NET Core 1.0 unofficial source browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SourceBrowser
-Source browser website generator that powers https://referencesource.microsoft.com, http://source.roslyn.io and https://source.dot.net.
+Source browser website generator that powers https://referencesource.microsoft.com, http://source.roslyn.io, https://source.dot.net, and https://aspnetsource.azurewebsites.net/ (unofficial ASP.NET Core 1.0 source).
 
 Create and host your own static HTML website to browse your C#/VB/MSBuild/TypeScript source code. **Note** that it still does require IIS and ASP.NET for hosting (symbol index is kept server-side), so [without IIS and ASP.NET the search function doesn't work](https://github.com/KirillOsenkov/SourceBrowser/wiki/Why-does-generated-Html-still-require-a-server-side-ASP.NET-Web-API%3F).
 


### PR DESCRIPTION
This adds the [unofficial](https://github.com/aspnet/Home/issues/1944#issuecomment-284155872)  version of ASP.NET Core 1.0 source browser to the list.

I can imagine you don't want an unofficial version of the source browser to be added here, and won't accept this PR. Though, for discoverability, this might be very useful, until an official version of ASP.NET Core is available.