### PR TITLE
Update MSBuildWorkspace to enable multi-targeted projects

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,8 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
+    <!-- This package feed is temporary until Microsoft.CodeAnalysis.Workspaces.MSBuild is released on https://nuget.org. -->
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -33,15 +33,17 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.0.7-preview-ge60d679b53" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.6.82" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.1" />
+    <!-- Temporarily use latest beta Roslyn packages until 2.9.0 is released on https://nuget.org. -->
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.9.0-beta4-62819-06" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.9.0-beta4-62819-06" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0-beta4-62819-06" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.9.0-beta4-62819-06" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.9.0-beta4-62819-06" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.9.0-beta4-62819-06" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="2.9.0-beta4-62819-06" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.9.0-beta4-62819-06" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0-beta4-62819-06" />
     <PackageReference Include="Microsoft.Language.Xml" Version="1.1.20" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="15.6.27413" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />

--- a/src/HtmlGenerator/Pass1-Generation/MetadataAsSource.cs
+++ b/src/HtmlGenerator/Pass1-Generation/MetadataAsSource.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.SourceBrowser.Common;
 
@@ -41,7 +42,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 {
                     var assemblyName = Path.GetFileNameWithoutExtension(assemblyFilePath);
 
-                    var solution = new AdhocWorkspace(WorkspaceHacks.Pack).CurrentSolution;
+                    var solution = new AdhocWorkspace(MefHostServices.DefaultHost).CurrentSolution;
                     var workspace = solution.Workspace;
                     var project = solution.AddProject(assemblyName, assemblyName, LanguageNames.CSharp);
                     var metadataReference = CreateReferenceFromFilePath(assemblyFilePath);

--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -128,7 +128,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             propertiesOpt = propertiesOpt.Add("VisualStudioVersion", "15.0");
             propertiesOpt = propertiesOpt.Add("AlwaysCompileMarkupFilesInSeparateDomain", "false");
 
-            var w = MSBuildWorkspace.Create(properties: propertiesOpt, hostServices: WorkspaceHacks.Pack);
+            var w = MSBuildWorkspace.Create(properties: propertiesOpt);
             w.LoadMetadataForReferencedProjects = true;
             return w;
         }

--- a/src/HtmlGenerator/Utilities/FirstChanceExceptionHandler.cs
+++ b/src/HtmlGenerator/Utilities/FirstChanceExceptionHandler.cs
@@ -91,6 +91,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     return;
                 }
 
+                if (ex is FileLoadException && ex.Message.Contains("The assembly '' has already loaded from a different location"))
+                {
+                    return;
+                }
+
                 if (ex is FileNotFoundException)
                 {
                     return;

--- a/src/HtmlGenerator/Utilities/WorkspaceHacks.cs
+++ b/src/HtmlGenerator/Utilities/WorkspaceHacks.cs
@@ -1,34 +1,12 @@
 ﻿using System;
-using System.ComponentModel.Composition.Hosting;
-using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
     public static class WorkspaceHacks
     {
-        public static HostServices Pack { get; set; }
-
-        static WorkspaceHacks()
-        {
-            var assemblyNames = new[]
-            {
-                "Microsoft.CodeAnalysis.Workspaces",
-                "Microsoft.CodeAnalysis.Workspaces.MSBuild",
-                "Microsoft.CodeAnalysis.CSharp.Workspaces",
-                "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
-                "Microsoft.CodeAnalysis.Features",
-                "Microsoft.CodeAnalysis.CSharp.Features",
-                "Microsoft.CodeAnalysis.VisualBasic.Features"
-            };
-            var assemblies = assemblyNames
-                .Select(n => Assembly.Load(n));
-            Pack = MefHostServices.Create(assemblies);
-        }
-
         public static dynamic GetSemanticFactsService(Document document)
         {
             return GetService(document, "Microsoft.CodeAnalysis.LanguageServices.ISemanticFactsService", "Microsoft.CodeAnalysis.Workspaces");

--- a/src/HtmlGenerator/Utilities/WorkspaceHacks.cs
+++ b/src/HtmlGenerator/Utilities/WorkspaceHacks.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var assemblyNames = new[]
             {
                 "Microsoft.CodeAnalysis.Workspaces",
-                "Microsoft.CodeAnalysis.Workspaces.Desktop",
+                "Microsoft.CodeAnalysis.Workspaces.MSBuild",
                 "Microsoft.CodeAnalysis.CSharp.Workspaces",
                 "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
                 "Microsoft.CodeAnalysis.Features",


### PR DESCRIPTION
Fixes https://github.com/KirillOsenkov/SourceBrowser/issues/84

This PR updates SourceBrowser to the latest Roslyn beta packages, which includes the `MSBuildWorkspace` update that adds support for multi-targeted projects. Note that this only enables processing of multi-targeted projects. Because SourceBrowser uses "assembly name" as part of path that it generates a project to, only a single target framework actually gets generated. Other target frameworks are skipped.

Proper handling of multi-targeted projects as part of SourceBrowser is a larger effort that will involve re-thinking of how project indices are laid out on disk and how links are generated to navigate between them.