### PR TITLE
Fix loading files with commas in the name

### DIFF
--- a/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceIndexServer/wwwroot/scripts.js
@@ -90,14 +90,6 @@ function processHash() {
             return;
         }
 
-        while (anchor.indexOf("%2C") != -1) {
-            anchor = anchor.replace("%2C", ",");
-        }
-
-        while (anchor.indexOf("%2c") != -1) {
-            anchor = anchor.replace("%2c", ",");
-        }
-
         var hashParts = anchor.split(anchorSplitChar);
         if (anchor.indexOf(anchorSplitChar) == -1 && anchor.indexOf("#") > -1) {
             // keep old URLs working for compat


### PR DESCRIPTION
A file's URL should only contain a comma if it directly precedes a
line number. In the case where a file's name actually contains a
comma, it should be encoded as %2C so the URL can still be split on
comma. This change prevents the encoded comma from being decoded
prematurely, resulting in an incorrect `potentialFile`. Furthermore,
it's completely unnecessary as `decodeURIComponent` on line 104 will
handle the decoding.