### PR TITLE
Treat .depproj as .csproj

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -130,6 +130,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             var w = MSBuildWorkspace.Create(properties: propertiesOpt);
             w.LoadMetadataForReferencedProjects = true;
+            w.AssociateFileExtensionWithLanguage("depproj", LanguageNames.CSharp);
             return w;
         }
 


### PR DESCRIPTION
Works around exceptions from MSBuildProjectLoader.Worker.LoadProjectInfosFromPathAsync adding the same key multiple times to a dictionary.