### PR TITLE
add netstandard2.0 for BuildLogParser.csproj

### DIFF
--- a/src/BuildLogParser/BuildLogParser.csproj
+++ b/src/BuildLogParser/BuildLogParser.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.SourceBrowser.BuildLogParser</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- add netstandard2.0 for BuildLogParser.csproj
- remove the reference for `Microsoft.Build`, because this has been referenced by `Common`