### PR TITLE
Log in an another thread to remove lock contention.

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -10,5 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="15.9.20" />
+    <PackageReference Include="System.Reactive" Version="4.1.5" />
   </ItemGroup>
 </Project>

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -209,6 +209,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 FinalizeProjects(emitAssemblyList, federation);
                 WebsiteFinalizer.Finalize(websiteDestination, emitAssemblyList, federation);
             }
+            Log.Close();
         }
 
         private static void AddProject(List<string> projects, string path)

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -16,6 +16,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
     {
         private static void Main(string[] args)
         {
+            Log.Activate();
             if (args.Length == 0)
             {
                 PrintUsage();

--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -16,7 +16,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
     {
         private static void Main(string[] args)
         {
-            Log.Activate();
             if (args.Length == 0)
             {
                 PrintUsage();


### PR DESCRIPTION
fix #122 

On test solution, here a dottrace snapshot:

![image](https://user-images.githubusercontent.com/10356780/61061320-4c60a900-a3fc-11e9-948f-e3e6130c2283.png)
we can see lock contention because own time is 54%.

With this PR, this method is reduce to 0 ms.