### PR TITLE
Defer init of nested solution browser folders until expand

### DIFF
--- a/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceIndexServer/wwwroot/scripts.js
@@ -1131,29 +1131,35 @@ function makeFoldersCollapsible(folderIcon, openFolderIcon, pathToIcons, initial
         var folder = elements[i];
         folder.style.display = 'none';
         folder.initialize = initializeHandler;
-        var div = folder.previousSibling;
-        var firstChild = div.firstChild;
-
-        var imagePlusMinus = document.createElement("img");
-        imagePlusMinus.src = pathToIcons + "plus.png";
-        imagePlusMinus.className = "imagePlusMinus";
-
-        var imageFolder = document.createElement("img");
-        imageFolder.src = pathToIcons + folderIcon;
-        imageFolder.className = "imageFolder";
-        setFolderImage(imageFolder, div, firstChild, pathToIcons, folderIcon);
-
-        var handler = expandCollapseFolder(folder, imagePlusMinus, imageFolder, div, firstChild, pathToIcons, folderIcon, openFolderIcon);
-
-        var skipImage = isLink(firstChild);
-        if (skipImage) {
-            div.insertBefore(imagePlusMinus, firstChild);
-            imagePlusMinus.onclick = handler;
-        } else {
-            div.insertBefore(imageFolder, firstChild);
-            div.insertBefore(imagePlusMinus, imageFolder);
-            div.onclick = handler;
+        if (folder.parentNode.id === 'rootFolder') {
+            addImagesToFolder(folder, folderIcon, openFolderIcon, pathToIcons);
         }
+    }
+}
+
+function addImagesToFolder(folder, folderIcon, openFolderIcon, pathToIcons) {
+    var div = folder.previousSibling;
+    var firstChild = div.firstChild;
+
+    var imagePlusMinus = document.createElement("img");
+    imagePlusMinus.src = pathToIcons + "plus.png";
+    imagePlusMinus.className = "imagePlusMinus";
+
+    var imageFolder = document.createElement("img");
+    imageFolder.src = pathToIcons + folderIcon;
+    imageFolder.className = "imageFolder";
+    setFolderImage(imageFolder, div, firstChild, pathToIcons, folderIcon);
+
+    var handler = expandCollapseFolder(folder, imagePlusMinus, imageFolder, div, firstChild, pathToIcons, folderIcon, openFolderIcon);
+
+    var skipImage = isLink(firstChild);
+    if (skipImage) {
+        div.insertBefore(imagePlusMinus, firstChild);
+        imagePlusMinus.onclick = handler;
+    } else {
+        div.insertBefore(imageFolder, firstChild);
+        div.insertBefore(imagePlusMinus, imageFolder);
+        div.onclick = handler;
     }
 }
 
@@ -1172,6 +1178,12 @@ function expandCollapseFolder(capturedFolder, capturedPlusMinus, capturedFolderI
             if (capturedFolder.initialize) {
                 capturedFolder.initialize(capturedFolder);
                 capturedFolder.initialize = null;
+
+                for (var i = 0; i < capturedFolder.children.length; i++) {
+                    if (capturedFolder.children[i].className === 'folder') {
+                        addImagesToFolder(capturedFolder.children[i], folderIcon, openFolderIcon, pathToIcons);
+                    }
+                }
             }
 
             capturedFolder.style.display = 'block';


### PR DESCRIPTION
Creating and inserting the img elements under folders in the DOM is slow. For a solution with many projects, the initialization done in makeFoldersCollapsible can take many seconds, or even minutes. This means that when loading the page, there is a long initial period where the page appears unresponsive.

This change addresses that problem by changing makeFoldersCollapsible so that it only initializes the top-level folders, which are initially collapsed. Only when a folder is expanded, do we initialize the contained folder items. 