### PR TITLE
Fix tree expansion for Project Explorer and Namespace Explorer

### DIFF
--- a/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceIndexServer/wwwroot/scripts.js
@@ -1133,7 +1133,9 @@ function makeFoldersCollapsible(folderIcon, openFolderIcon, pathToIcons, initial
         var folder = elements[i];
         folder.style.display = 'none';
         folder.initialize = initializeHandler;
-        if (folder.parentNode.id === 'rootFolder') {
+        if (folder.parentNode.id === 'rootFolder'
+         || folder.parentNode.previousSibling.id === 'rootFolder'
+         || folder.parentNode.className === 'namespaceExplorerBody') {
             addImagesToFolder(folder, folderIcon, openFolderIcon, pathToIcons);
         }
     }
@@ -1180,7 +1182,9 @@ function expandCollapseFolder(capturedFolder, capturedPlusMinus, capturedFolderI
             if (capturedFolder.initialize) {
                 capturedFolder.initialize(capturedFolder);
                 capturedFolder.initialize = null;
-
+            }
+            
+            if (!capturedFolder.everExpanded) {
                 for (var i = 0; i < capturedFolder.children.length; i++) {
                     if (capturedFolder.children[i].className === 'folder') {
                         addImagesToFolder(capturedFolder.children[i], folderIcon, openFolderIcon, pathToIcons);
@@ -1188,6 +1192,7 @@ function expandCollapseFolder(capturedFolder, capturedPlusMinus, capturedFolderI
                 }
             }
 
+            capturedFolder.everExpanded = true;
             capturedFolder.style.display = 'block';
         }
         else {


### PR DESCRIPTION
My previous optimization to defer adding folder images was missing support for the Project Explorer and Namespace Explorer (it only worked for Solution Explorer). This change does two things:
1. Ensures that top-level items in the Project/Namespace explorers get proper images upon initial display
2. Ensures that expanding an item for the first time adds images to contained, child folders, even if the item's `initialize` attribute is unset