### PR TITLE
Test file existence of the Projects file rather than the folder

### DIFF
--- a/src/SourceIndexServer/Models/Serialization.cs
+++ b/src/SourceIndexServer/Models/Serialization.cs
@@ -25,7 +25,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
         public static IEnumerable<string> ReadProjects(string folderPath)
         {
             var projectInfoFile = Path.Combine(folderPath, Constants.MasterProjectMap + ".txt");
-            if (!File.Exists(folderPath))
+            if (!File.Exists(projectInfoFile))
             {
                 return Array.Empty<string>();
             }


### PR DESCRIPTION
There was a recent change to make Source Browser more resilient to individual files being missing. It seems there was a copy-paste error where File.Exists was being called on a directory, rather than the Projects.txt file. This seems to break index loading, because an empty project array is returned.