### PR TITLE
Dark mode arrows

### DIFF
--- a/src/SourceIndexServer/wwwroot/scripts.js
+++ b/src/SourceIndexServer/wwwroot/scripts.js
@@ -461,10 +461,10 @@ function ro() {
             var collapsible = this.nextSibling;
             if (collapsible.style.display == "none") {
                 collapsible.style.display = "block";
-                this.style.backgroundImage = "url(../../content/icons/minus.png)";
+                this.classList.remove('collapsed');
             } else {
                 collapsible.style.display = "none";
-                this.style.backgroundImage = "url(../../content/icons/plus.png)";
+                this.classList.add('collapsed');
             }
         };
     }
@@ -1066,11 +1066,11 @@ function redirectToSymbolReferences() {
 function toggle(header, id) {
     var element = document.getElementById(id);
     if (element.style.display == 'none') {
-        header.style.backgroundImage = "url(content/icons/minus.png)";
+        header.classList.remove("collapsed");
         element.style.display = 'block';
     }
     else {
-        header.style.backgroundImage = "url(content/icons/plus.png)";
+        header.classList.add("collapsed");
         element.style.display = 'none';
     }
 }

--- a/src/SourceIndexServer/wwwroot/styles.css
+++ b/src/SourceIndexServer/wwwroot/styles.css
@@ -122,16 +122,22 @@ tr td.ex {
     padding: 6px 6px 6px 28px;
     margin-top: 16px;
     background-color: #e7f5ff;
-    background-image: url('content/icons/minus.png');
-    background-attachment: local;
-    background-repeat: no-repeat;
-    background-position: 10px 13px;
-    background-origin: border-box;
 }
 
-    .resultGroupHeader:hover {
-        background-color: #d4edff;
-    }
+.resultGroupHeader::before {
+    content: url(content/icons/minus.png);
+    float: left;
+    margin-left: -18px;
+    margin-top: 1px;
+}
+
+.resultGroupHeader.collapsed::before {
+    content: url(content/icons/plus.png);
+}
+
+.resultGroupHeader:hover {
+    background-color: #d4edff;
+}
 
 .resultGroupAssemblyName {
     font-size: larger;
@@ -142,18 +148,24 @@ tr td.ex {
     font-size: larger;
     font-weight: bold;
     background-color: #e7f5ff;
-    background-image: url('content/icons/minus.png');
-    background-attachment: local;
-    background-repeat: no-repeat;
-    background-position: 10px 14px;
-    background-origin: border-box;
     padding: 6px 6px 6px 28px;
     cursor: pointer;
 }
 
-    .rA:hover {
-        background-color: #d4edff;
-    }
+.rA::before {
+    content: url(content/icons/minus.png);
+    float: left;
+    margin-left: -18px;
+    margin-top: -2px;
+}
+
+.rA.collapsed::before {
+    content: url(content/icons/plus.png);
+}
+
+.rA:hover {
+    background-color: #d4edff;
+}
 
 .resultGroupProjectPath {
     font-size: smaller;

--- a/src/SourceIndexServer/wwwroot/styles.css
+++ b/src/SourceIndexServer/wwwroot/styles.css
@@ -1109,6 +1109,10 @@ ol a, ol a:link, ol a:hover, ol a:focus, ol a:active,
         color: #aaa;
     }
 
+    .imagePlusMinus, .resultGroupHeader::before, .rA::before {
+        filter: invert(1);
+    }
+
     html {
         background: black;
     }


### PR DESCRIPTION
Fixes #163. In the refactoring commit, I aligned the icons to the same pixels by switching between 'before' and 'after' tabs and verifying that the icons didn't move. I made sure everything looked good in Firefox, Chrome, and Edge on Windows 10.

### Class `imagePlusMinus`

Before/after:

![image](https://user-images.githubusercontent.com/8040367/115133740-7b944900-9fd8-11eb-8324-e783016b7391.png) ![image](https://user-images.githubusercontent.com/8040367/115133701-2ce6af00-9fd8-11eb-8e53-578ea4401577.png)

### Class `resultGroupHeader`

Before:

![image](https://user-images.githubusercontent.com/8040367/115133748-95359080-9fd8-11eb-9953-8a3a7b3e045e.png)

After:

![image](https://user-images.githubusercontent.com/8040367/115133693-14769480-9fd8-11eb-9039-7c765f20e5c6.png)

### Class `rA`

Before:

![image](https://user-images.githubusercontent.com/8040367/115133650-e3965f80-9fd7-11eb-8608-197968b7364b.png)

After:

![image](https://user-images.githubusercontent.com/8040367/115133661-eee98b00-9fd7-11eb-9bfa-f2dc048b137e.png)
