### PR TITLE
Fix blank page for source filenames starting with '.'

### DIFF
--- a/src/SourceIndexServer/Startup.cs
+++ b/src/SourceIndexServer/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
 using Microsoft.Extensions.Hosting;
 using Microsoft.SourceBrowser.SourceIndexServer.Models;
 
@@ -53,7 +54,7 @@ namespace Microsoft.SourceBrowser.SourceIndexServer
             app.UseDefaultFiles();
             app.UseStaticFiles(new StaticFileOptions
             {
-                FileProvider = new PhysicalFileProvider(RootPath),
+                FileProvider = new PhysicalFileProvider(RootPath, ExclusionFilters.Sensitive & ~ExclusionFilters.DotPrefixed),
             });
             app.UseStaticFiles();
             app.UseRouting();


### PR DESCRIPTION
Fixes #171. Right pane is no longer blank and logging a 404 in the browser console when the filename starting with `.` is clicked:

![image](https://user-images.githubusercontent.com/8040367/115644998-8fe48880-a2ed-11eb-9d3d-69a2b484d73a.png)
