### PR TITLE
Fix a typo that caused exit showing usage if /p was not used

### DIFF
--- a/src/HtmlGenerator/Program.cs
+++ b/src/HtmlGenerator/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         {
             var options = CommandLineOptions.Parse(args);
 
-            if (options.Properties.Count == 0)
+            if (options.Projects.Count == 0)
             {
                 PrintUsage();
                 return;


### PR DESCRIPTION
Regressed in https://github.com/KirillOsenkov/SourceBrowser/pull/168