### PR TITLE
Enable 'Web Access' link for XML files

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -282,23 +282,9 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string projectDisplayName = projectGenerator.ProjectSourcePath;
             string projectUrl = "/#" + Document.Project.AssemblyName;
 
-            string documentLink = string.Format("File: <a id=\"filePath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a><br/>", "/#" + DocumentUrl, documentDisplayName);
-            string projectLink = string.Format("Project: <a id=\"projectPath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a> ({2})", projectUrl, projectDisplayName, projectGenerator.AssemblyName);
-
             string webLink = GetWebLink();
-            if (webLink != null)
-            {
-                webLink = Markup.A(webLink, "Web&nbsp;Access", "_blank");
-            }
-            else
-            {
-                webLink = "";
-            }
 
-            string firstRow = string.Format("<tr><td>{0}</td><td>{1}</td></tr>", documentLink, webLink);
-            string secondRow = string.Format("<tr><td>{0}</td></tr>", projectLink);
-
-            Markup.WriteLinkPanel(writeLine, firstRow, secondRow);
+            Markup.WriteLinkPanel(writeLine, (documentDisplayName, "/#" + DocumentUrl), webLink, (projectDisplayName, projectUrl, projectGenerator.AssemblyName));
         }
 
         private string GetWebLink()

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -278,15 +278,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private void GenerateHeader(Action<string> writeLine)
         {
-            string documentDisplayName = documentRelativeFilePathWithoutHtmlExtension;
-            string projectDisplayName = projectGenerator.ProjectSourcePath;
-            string projectUrl = "/#" + Document.Project.AssemblyName;
-
             Markup.WriteLinkPanel(
                 writeLine,
-                (documentDisplayName, "/#" + DocumentUrl),
-                projectGenerator.GetWebAccessUrl(Document.FilePath),
-                (projectDisplayName, projectUrl, projectGenerator.AssemblyName));
+                fileLink: (Display: documentRelativeFilePathWithoutHtmlExtension, Url: "/#" + DocumentUrl),
+                webAccessUrl: projectGenerator.GetWebAccessUrl(Document.FilePath),
+                projectLink: (Display: projectGenerator.ProjectSourcePath, Url: "/#" + Document.Project.AssemblyName, projectGenerator.AssemblyName));
         }
 
         private async Task GeneratePre(StreamWriter writer, int lineCount = 0)

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -285,16 +285,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string documentLink = string.Format("File: <a id=\"filePath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a><br/>", "/#" + DocumentUrl, documentDisplayName);
             string projectLink = string.Format("Project: <a id=\"projectPath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a> ({2})", projectUrl, projectDisplayName, projectGenerator.AssemblyName);
 
-            string fileShareLink = GetFileShareLink();
-            if (fileShareLink != null)
-            {
-                fileShareLink = Markup.A(fileShareLink, "File", "_blank");
-            }
-            else
-            {
-                fileShareLink = "";
-            }
-
             string webLink = GetWebLink();
             if (webLink != null)
             {
@@ -306,7 +296,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             }
 
             string firstRow = string.Format("<tr><td>{0}</td><td>{1}</td></tr>", documentLink, webLink);
-            string secondRow = string.Format("<tr><td>{0}</td><td>{1}</td></tr>", projectLink, fileShareLink);
+            string secondRow = string.Format("<tr><td>{0}</td></tr>", projectLink);
 
             Markup.WriteLinkPanel(writeLine, firstRow, secondRow);
         }
@@ -322,28 +312,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             }
 
             return null;
-        }
-
-        private string GetDocumentPathFromSourceSolutionRoot()
-        {
-            string projectPath = Path.GetDirectoryName(projectGenerator.ProjectSourcePath);
-            string filePath = @"C:\" + Path.Combine(projectPath, documentRelativeFilePathWithoutHtmlExtension);
-            filePath = Path.GetFullPath(filePath);
-            filePath = filePath.Substring(3); // strip the artificial "C:\"
-            return filePath;
-        }
-
-        private string GetFileShareLink()
-        {
-            var networkShare = this.projectGenerator.SolutionGenerator.NetworkShare;
-            if (string.IsNullOrEmpty(networkShare))
-            {
-                return null;
-            }
-
-            string filePath = GetDocumentPathFromSourceSolutionRoot();
-            filePath = Path.Combine(networkShare, filePath);
-            return filePath;
         }
 
         private async Task GeneratePre(StreamWriter writer, int lineCount = 0)

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -282,22 +282,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string projectDisplayName = projectGenerator.ProjectSourcePath;
             string projectUrl = "/#" + Document.Project.AssemblyName;
 
-            string webLink = GetWebLink();
-
-            Markup.WriteLinkPanel(writeLine, (documentDisplayName, "/#" + DocumentUrl), webLink, (projectDisplayName, projectUrl, projectGenerator.AssemblyName));
-        }
-
-        private string GetWebLink()
-        {
-            var fullPath = Path.GetFullPath(Document.FilePath);
-            var serverPathMapping =
-                projectGenerator.SolutionGenerator.ServerPathMappings.FirstOrDefault(p => fullPath.StartsWith(p.Key, StringComparison.OrdinalIgnoreCase));
-            if (serverPathMapping.Key != null)
-            {
-                return serverPathMapping.Value + fullPath.Substring(serverPathMapping.Key.Length).Replace('\\', '/');
-            }
-
-            return null;
+            Markup.WriteLinkPanel(
+                writeLine,
+                (documentDisplayName, "/#" + DocumentUrl),
+                projectGenerator.GetWebAccessUrl(Document.FilePath),
+                (projectDisplayName, projectUrl, projectGenerator.AssemblyName));
         }
 
         private async Task GeneratePre(StreamWriter writer, int lineCount = 0)

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -321,22 +321,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 return serverPathMapping.Value + fullPath.Substring(serverPathMapping.Key.Length).Replace('\\', '/');
             }
 
-            var serverPath = this.projectGenerator.SolutionGenerator.ServerPath;
-            if (string.IsNullOrEmpty(serverPath))
-            {
-                return null;
-            }
-
-            string filePath = GetDocumentPathFromSourceSolutionRoot();
-            filePath = filePath.Replace('\\', '/');
-
-            const string urlTemplate = "{0}{1}";
-
-            string url = string.Format(
-                urlTemplate,
-                serverPath,
-                filePath);
-            return url;
+            return null;
         }
 
         private string GetDocumentPathFromSourceSolutionRoot()

--- a/src/HtmlGenerator/Pass1-Generation/GenerateFromBuildLog.cs
+++ b/src/HtmlGenerator/Pass1-Generation/GenerateFromBuildLog.cs
@@ -38,7 +38,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         invocation.OutputAssemblyPath,
                         invocation.SolutionRoot,
                         Paths.SolutionDestinationFolder,
-                        invocation.ServerPath,
                         invocation.NetworkShare);
                     solutionGenerator.ServerPathMappings = serverPathMappings;
                     solutionGenerator.GlobalAssemblyList = assemblyNames;
@@ -70,7 +69,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     OutputAssemblyPath = lines[i + 1],
                     CommandLineArguments = lines[i + 2],
                     NetworkShare = "",
-                    ServerPath = "",
                     SolutionRoot = "",
                 };
 
@@ -102,7 +100,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             public string ProjectDirectory => ProjectFilePath == null ? "" : Path.GetDirectoryName(ProjectFilePath);
             public string OutputAssemblyPath { get; set; }
             public string CommandLineArguments { get; set; }
-            public string ServerPath { get; set; }
             public string NetworkShare { get; set; }
             public string SolutionRoot { get; set; }
             public IEnumerable<string> TypeScriptFiles { get; set; }

--- a/src/HtmlGenerator/Pass1-Generation/GenerateFromBuildLog.cs
+++ b/src/HtmlGenerator/Pass1-Generation/GenerateFromBuildLog.cs
@@ -37,8 +37,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         invocation.CommandLineArguments,
                         invocation.OutputAssemblyPath,
                         invocation.SolutionRoot,
-                        Paths.SolutionDestinationFolder,
-                        invocation.NetworkShare);
+                        Paths.SolutionDestinationFolder);
                     solutionGenerator.ServerPathMappings = serverPathMappings;
                     solutionGenerator.GlobalAssemblyList = assemblyNames;
                     solutionGenerator.Generate(processedAssemblyList, solutionExplorerRoot);
@@ -68,7 +67,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     ProjectFilePath = lines[i],
                     OutputAssemblyPath = lines[i + 1],
                     CommandLineArguments = lines[i + 2],
-                    NetworkShare = "",
                     SolutionRoot = "",
                 };
 
@@ -100,7 +98,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             public string ProjectDirectory => ProjectFilePath == null ? "" : Path.GetDirectoryName(ProjectFilePath);
             public string OutputAssemblyPath { get; set; }
             public string CommandLineArguments { get; set; }
-            public string NetworkShare { get; set; }
             public string SolutionRoot { get; set; }
             public IEnumerable<string> TypeScriptFiles { get; set; }
 

--- a/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
@@ -242,5 +242,17 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string subfolder = Path.Combine(solutionDestinationPath, AssemblyName);
             return subfolder;
         }
+
+        public string GetWebAccessUrl(string sourceFilePath)
+        {
+            var fullPath = Path.GetFullPath(sourceFilePath);
+            var serverPathMapping = SolutionGenerator.ServerPathMappings.FirstOrDefault(p => fullPath.StartsWith(p.Key, StringComparison.OrdinalIgnoreCase));
+            if (serverPathMapping.Key != null)
+            {
+                return serverPathMapping.Value + fullPath.Substring(serverPathMapping.Key.Length).Replace('\\', '/');
+            }
+
+            return null;
+        }
     }
 }

--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -18,7 +18,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         public string SolutionSourceFolder { get; private set; }
         public string SolutionDestinationFolder { get; private set; }
         public string ProjectFilePath { get; private set; }
-        public string ServerPath { get; set; }
         public IReadOnlyDictionary<string, string> ServerPathMappings { get; set; }
         public string NetworkShare { get; private set; }
         private Federation Federation { get; set; }
@@ -37,7 +36,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         public SolutionGenerator(
             string solutionFilePath,
             string solutionDestinationFolder,
-            string serverPath = null,
             ImmutableDictionary<string, string> properties = null,
             Federation federation = null,
             IReadOnlyDictionary<string, string> serverPathMappings = null,
@@ -47,7 +45,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             this.SolutionSourceFolder = Path.GetDirectoryName(solutionFilePath);
             this.SolutionDestinationFolder = solutionDestinationFolder;
             this.ProjectFilePath = solutionFilePath;
-            this.ServerPath = serverPath;
             ServerPathMappings = serverPathMappings;
             this.solution = CreateSolution(solutionFilePath, properties, doNotIncludeReferencedProjects);
             this.Federation = federation ?? new Federation();
@@ -93,7 +90,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string outputAssemblyPath,
             string solutionSourceFolder,
             string solutionDestinationFolder,
-            string serverPath,
             string networkShare)
         {
             this.ProjectFilePath = projectFilePath;
@@ -102,7 +98,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 LanguageNames.VisualBasic : LanguageNames.CSharp;
             this.SolutionSourceFolder = solutionSourceFolder;
             this.SolutionDestinationFolder = solutionDestinationFolder;
-            this.ServerPath = serverPath;
             this.NetworkShare = networkShare;
             string projectSourceFolder = Path.GetDirectoryName(projectFilePath);
             SetupPluginAggregator();

--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -19,7 +19,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         public string SolutionDestinationFolder { get; private set; }
         public string ProjectFilePath { get; private set; }
         public IReadOnlyDictionary<string, string> ServerPathMappings { get; set; }
-        public string NetworkShare { get; private set; }
         private Federation Federation { get; set; }
         public IEnumerable<string> PluginBlacklist { get; private set; }
         private readonly HashSet<string> typeScriptFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -89,8 +88,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             string commandLineArguments,
             string outputAssemblyPath,
             string solutionSourceFolder,
-            string solutionDestinationFolder,
-            string networkShare)
+            string solutionDestinationFolder)
         {
             this.ProjectFilePath = projectFilePath;
             string projectName = Path.GetFileNameWithoutExtension(projectFilePath);
@@ -98,7 +96,6 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 LanguageNames.VisualBasic : LanguageNames.CSharp;
             this.SolutionSourceFolder = solutionSourceFolder;
             this.SolutionDestinationFolder = solutionDestinationFolder;
-            this.NetworkShare = networkShare;
             string projectSourceFolder = Path.GetDirectoryName(projectFilePath);
             SetupPluginAggregator();
 

--- a/src/HtmlGenerator/Pass1-Generation/TypeScriptSupport.cs
+++ b/src/HtmlGenerator/Pass1-Generation/TypeScriptSupport.cs
@@ -189,9 +189,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var url = "/#" + assemblyName + "/" + displayName.Replace('\\', '/');
             displayName = @"\\" + displayName;
 
-            var file = string.Format("File: <a id=\"filePath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a><br/>", url, displayName);
-            var row = string.Format("<tr><td>{0}</td></tr>", file);
-            Markup.WriteLinkPanel(s => sb.AppendLine(s), row);
+            Markup.WriteLinkPanel(s => sb.AppendLine(s), fileLink: (displayName, url));
 
             // pass a value larger than 0 to generate line numbers statically at HTML generation time
             var table = Markup.GetTablePrefix();

--- a/src/HtmlGenerator/Pass1-Generation/XmlSupport.cs
+++ b/src/HtmlGenerator/Pass1-Generation/XmlSupport.cs
@@ -55,7 +55,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             var url = "/#" + assemblyName + "/" + displayName.Replace('\\', '/');
 
-            Markup.WriteLinkPanel(s => sb.AppendLine(s), fileLink: (displayName, url), ProjectGenerator.GetWebAccessUrl(sourceXmlFilePath));
+            Markup.WriteLinkPanel(
+                s => sb.AppendLine(s),
+                fileLink: (displayName, url),
+                webAccessUrl: ProjectGenerator.GetWebAccessUrl(sourceXmlFilePath),
+                projectLink: (ProjectGenerator.ProjectSourcePath, Url: "/#" + assemblyName, assemblyName));
 
             // pass a value larger than 0 to generate line numbers statically at HTML generation time
             var table = Markup.GetTablePrefix();

--- a/src/HtmlGenerator/Pass1-Generation/XmlSupport.cs
+++ b/src/HtmlGenerator/Pass1-Generation/XmlSupport.cs
@@ -55,7 +55,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             var url = "/#" + assemblyName + "/" + displayName.Replace('\\', '/');
 
-            Markup.WriteLinkPanel(s => sb.AppendLine(s), fileLink: (displayName, url));
+            Markup.WriteLinkPanel(s => sb.AppendLine(s), fileLink: (displayName, url), ProjectGenerator.GetWebAccessUrl(sourceXmlFilePath));
 
             // pass a value larger than 0 to generate line numbers statically at HTML generation time
             var table = Markup.GetTablePrefix();

--- a/src/HtmlGenerator/Pass1-Generation/XmlSupport.cs
+++ b/src/HtmlGenerator/Pass1-Generation/XmlSupport.cs
@@ -55,9 +55,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             var url = "/#" + assemblyName + "/" + displayName.Replace('\\', '/');
 
-            var file = string.Format("File: <a id=\"filePath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a><br/>", url, displayName);
-            var row = string.Format("<tr><td>{0}</td></tr>", file);
-            Markup.WriteLinkPanel(s => sb.AppendLine(s), row);
+            Markup.WriteLinkPanel(s => sb.AppendLine(s), fileLink: (displayName, url));
 
             // pass a value larger than 0 to generate line numbers statically at HTML generation time
             var table = Markup.GetTablePrefix();

--- a/src/HtmlGenerator/Utilities/Markup.cs
+++ b/src/HtmlGenerator/Utilities/Markup.cs
@@ -227,14 +227,28 @@ Don't use this page directly, pass #symbolId to get redirected.
             writer.WriteLine(contents);
         }
 
-        public static void WriteLinkPanel(Action<string> writeLine, params string[] rows)
+        public static void WriteLinkPanel(
+            Action<string> writeLine,
+            (string Display, string Url) fileLink,
+            string webAccessUrl = null,
+            (string Display, string Url, string AssemblyName)? projectLink = null)
         {
             writeLine("<div class=\"dH\">");
             writeLine("<table style=\"width: 100%\">");
 
-            foreach (var row in rows)
+            string fileCellContents = string.Format("File: <a id=\"filePath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a><br/>", fileLink.Url, fileLink.Display);
+
+            var webAccessCellContents = webAccessUrl is object
+                ? A(webAccessUrl, "Web&nbsp;Access", "_blank")
+                : null;
+
+            writeLine(string.Format("<tr><td>{0}</td><td>{1}</td></tr>", fileCellContents, webAccessCellContents));
+
+            if (projectLink is object)
             {
-                writeLine(row);
+                string projectCellContents = string.Format("Project: <a id=\"projectPath\" class=\"blueLink\" href=\"{0}\" target=\"_top\">{1}</a> ({2})", projectLink.Value.Url, projectLink.Value.Display, projectLink.Value.AssemblyName);
+
+                writeLine(string.Format("<tr><td>{0}</td></tr>", projectCellContents));
             }
 
             writeLine("</table>");


### PR DESCRIPTION
Closes #170

Example:
![image](https://user-images.githubusercontent.com/8040367/115968639-d3fea580-a506-11eb-895e-9c7c0617be16.png)

I thought about unifying the links when the file path is the same as the project path, but the links do different things and it seems better to keep that.

TypeScript support required changes that were more extensive than I felt comfortable doing without testing, but it should be easier to do that part now if anyone wants to.