### PR TITLE
Omit 'Web Access' link for files untracked by most gitignores

### DIFF
--- a/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.SourceBrowser.Common;
@@ -245,11 +246,15 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         public string GetWebAccessUrl(string sourceFilePath)
         {
-            var fullPath = Path.GetFullPath(sourceFilePath);
-            var serverPathMapping = SolutionGenerator.ServerPathMappings.FirstOrDefault(p => fullPath.StartsWith(p.Key, StringComparison.OrdinalIgnoreCase));
-            if (serverPathMapping.Key != null)
+            // Align with most gitignores as an approximation for knowing whether the file will exist in the source control repository.
+            if (!Regex.IsMatch(sourceFilePath, @"(?:[/\\]|\A)obj[/\\]"))
             {
-                return serverPathMapping.Value + fullPath.Substring(serverPathMapping.Key.Length).Replace('\\', '/');
+                var fullPath = Path.GetFullPath(sourceFilePath);
+                var serverPathMapping = SolutionGenerator.ServerPathMappings.FirstOrDefault(p => fullPath.StartsWith(p.Key, StringComparison.OrdinalIgnoreCase));
+                if (serverPathMapping.Key != null)
+                {
+                    return serverPathMapping.Value + fullPath.Substring(serverPathMapping.Key.Length).Replace('\\', '/');
+                }
             }
 
             return null;


### PR DESCRIPTION
Closes #169

File with `obj` path segment:

![image](https://user-images.githubusercontent.com/8040367/115971574-2942b300-a517-11eb-9c3f-b4fb9f27dd56.png)

File without `obj` path segment:

![image](https://user-images.githubusercontent.com/8040367/115971567-20ea7800-a517-11eb-8364-ee4f801a8e60.png)
