### PR TITLE
Fix background hidden overflow problem in sidebar with horizontal scroll

### DIFF
--- a/src/SourceIndexServer/wwwroot/styles.css
+++ b/src/SourceIndexServer/wwwroot/styles.css
@@ -1,4 +1,8 @@
-﻿body {
+﻿html {
+    display: flex;
+}
+
+body {
     font-family: Segoe UI, Tahoma, Helvetica, sans-serif;
     cursor: text;
     margin: 0px;


### PR DESCRIPTION
Before:
![Screenshot_3](https://user-images.githubusercontent.com/4404199/141841907-a834ca6a-3cc8-424f-b552-9ec7179e9b95.png)

After:
![Screenshot_4](https://user-images.githubusercontent.com/4404199/141841934-63cf9a03-b987-4bef-b255-d7df27ff9e36.png)

Ref: https://source.dot.net/#System.Linq/System/Linq/ToCollection.cs,c7f3fa13329a79cd,references

A quick fix for something I noticed a lot that made some of the text less readable when doing horizontal scrolling when there are lots of references.

Note that this means the titles won't wrap anymore, which I think is totally fine. But if that's important I can think of a couple of ways to work around it if needed. What do you think?