### PR TITLE
Make body stretch to flex parent

### DIFF
--- a/src/SourceIndexServer/wwwroot/styles.css
+++ b/src/SourceIndexServer/wwwroot/styles.css
@@ -7,6 +7,7 @@ body {
     cursor: text;
     margin: 0px;
     padding: 0px;
+    flex: 1;
 }
 
 .body, p, ul, ol, h1, h2, h3 {


### PR DESCRIPTION
Before:
![Screenshot_2](https://user-images.githubusercontent.com/4404199/158585195-c80c77d8-94d7-4e3c-8e3c-fe6afb2d856b.png)

After:
![Screenshot_3](https://user-images.githubusercontent.com/4404199/158585217-43b63d96-1704-4b02-bd37-c6700da28a79.png)

This is an extremely straightforward fix in CSS. When you wanna go flex, you usually want to go flex all the way, but in the bg PR I wanted to change the least amount of CSS I could. In any case, this should work as expected now.

As you can see this also fixes a problem in the header caused by #201 too (at the time didn't realize the same styles were being applied to the header too).

Do note though that I wasn't able to test this one locally because of problems generating the test solution (since it uses .net 4.5 and apparently I don't have the dev pack for it), so you might want to do a quick run to make sure it works fine.

Resolves #209 