### PR TITLE
Update Roslyn to v4.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ bld/
 # Visual Studo 2015 cache/options directory
 .vs/
 
+# Rider
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -15,7 +15,8 @@
     <NuGetPackageId>SourceBrowser</NuGetPackageId>
     <NuSpecFile>$(MSBuildProjectDirectory)\$(NuGetPackageId).nuspec</NuSpecFile>
     <NuGetVersion>1.0.38</NuGetVersion>
-    <NuGetVersionRoslyn>4.0.0-1.final</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>4.4.0</NuGetVersionRoslyn>
+    <NuGetVersionMSBuild>16.10.0</NuGetVersionMSBuild>
   </PropertyGroup>
   <ItemGroup>
     <NuGetInput Include="$(MSBuildThisFile)" />
@@ -35,13 +36,13 @@
   <ItemGroup>
     <PackageReference Include="ExceptionAnalysis.Diagnostics" Version="1.0.0.39796" />
     <PackageReference Include="ManagedEsent" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.10.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/HtmlGenerator/Utilities/WorkspaceHacks.cs
+++ b/src/HtmlGenerator/Utilities/WorkspaceHacks.cs
@@ -9,12 +9,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
     {
         public static dynamic GetSemanticFactsService(Document document)
         {
-            return GetService(document, "Microsoft.CodeAnalysis.LanguageServices.ISemanticFactsService", "Microsoft.CodeAnalysis.Workspaces");
+            return GetService(document, "Microsoft.CodeAnalysis.LanguageService.ISemanticFactsService", "Microsoft.CodeAnalysis.Workspaces");
         }
 
         public static dynamic GetSyntaxFactsService(Document document)
         {
-            return GetService(document, "Microsoft.CodeAnalysis.LanguageServices.ISyntaxFactsService", "Microsoft.CodeAnalysis.Workspaces");
+            return GetService(document, "Microsoft.CodeAnalysis.LanguageService.ISyntaxFactsService", "Microsoft.CodeAnalysis.Workspaces");
         }
 
         public static object GetMetadataAsSourceService(Document document)
@@ -33,7 +33,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             var languageServicesType = typeof(HostLanguageServices);
             var genericMethod = languageServicesType.GetMethod("GetService", BindingFlags.Public | BindingFlags.Instance);
             var closedGenericMethod = genericMethod.MakeGenericMethod(serviceType);
-            var result = closedGenericMethod.Invoke(languageServices, new object[0]);
+            var result = closedGenericMethod.Invoke(languageServices, Array.Empty<object>());
             if (result == null)
             {
                 throw new NullReferenceException("Unable to get language service: " + serviceType.FullName + " for " + language);
@@ -44,13 +44,11 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
         private static object GetService(Document document, string serviceType, string assemblyName)
         {
-            var assembly = typeof(Document).Assembly;
-            var documentExtensions = assembly.GetType("Microsoft.CodeAnalysis.Shared.Extensions.DocumentExtensions");
             var serviceAssembly = Assembly.Load(assemblyName);
             var serviceInterfaceType = serviceAssembly.GetType(serviceType);
-            var getLanguageServiceMethod = documentExtensions.GetMethod("GetLanguageService", new Type[] { typeof(Document) });
-            getLanguageServiceMethod = getLanguageServiceMethod.MakeGenericMethod(serviceInterfaceType);
-            var service = getLanguageServiceMethod.Invoke(null, new object[] { document });
+            var genericMethod = typeof(LanguageServices).GetMethod(nameof(LanguageServices.GetService), BindingFlags.Public | BindingFlags.Instance);
+            var closedGenericMethod = genericMethod.MakeGenericMethod(serviceInterfaceType);
+            var service = closedGenericMethod.Invoke(document.Project.Services, Array.Empty<object>());
             return service;
         }
     }


### PR DESCRIPTION
This PR updates Roslyn to v4.4.0.

I was getting the following error with the .NET 7 SDK:

```
Unhandled Exception: System.MissingMethodException: Method not found: 'Void Microsoft.NET.StringTools.SpanBasedStringBuilder.Append(System.ReadOnlyMemory`1<Char>)'.
  at Microsoft.Build.Evaluation.Expander`2.SpanBasedConcatenator.Add(ReadOnlyMemory`1 span)
  at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertiesLeaveTypedAndEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem, LoggingContext loggingContext)
  at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertiesLeaveEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties, IFileSystem fileSystem, LoggingContext loggingContext)
  at Microsoft.Build.Evaluation.Expander`2.ExpandIntoStringLeaveEscaped(String expression, ExpanderOptions options, IElementLocation elementLocation, LoggingContext loggingContext)
  at Microsoft.Build.Evaluation.ToolsetReader.ExpandPropertyUnescaped(ToolsetPropertyDefinition property, Expander`2 expander)
  at Microsoft.Build.Evaluation.ToolsetReader.EvaluateAndSetProperty(ToolsetPropertyDefinition property, PropertyDictionary`1 properties, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties, String& toolsPath, String& binPath, Expander`2& expander)
  at Microsoft.Build.Evaluation.ToolsetReader.ReadToolset(ToolsetPropertyDefinition toolsVersion, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties)
  at Microsoft.Build.Evaluation.ToolsetReader.ReadEachToolset(Dictionary`2 toolsets, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties)
  at Microsoft.Build.Evaluation.ToolsetReader.ReadToolsets(Dictionary`2 toolsets, PropertyDictionary`1 globalProperties, PropertyDictionary`1 initialProperties, Boolean accumulateProperties, String& msBuildOverrideTasksPath, String& defaultOverrideToolsVersion)
  at Microsoft.Build.Evaluation.ToolsetReader.<ReadAllToolsets>g__ReadConfigToolset|12_0(<>c__DisplayClass12_0& )
  at Microsoft.Build.Evaluation.ToolsetReader.ReadAllToolsets(Dictionary`2 toolsets, ToolsetRegistryReader registryReader, ToolsetConfigurationReader configurationReader, PropertyDictionary`1 environmentProperties, PropertyDictionary`1 globalProperties, ToolsetDefinitionLocations locations)
  at Microsoft.Build.Evaluation.ProjectCollection.InitializeToolsetCollection(ToolsetRegistryReader registryReader, ToolsetConfigurationReader configReader)
  at Microsoft.Build.Evaluation.ProjectCollection..ctor(IDictionary`2 globalProperties, IEnumerable`1 loggers, IEnumerable`1 remoteLoggers, ToolsetDefinitionLocations toolsetDefinitionLocations, Int32 maxNodeCount, Boolean onlyLogCriticalEvents, Boolean loadProjectsReadOnly, Boolean useAsynchronousLogging, Boolean reuseProjectRootElementCache)
  at Microsoft.Build.Evaluation.ProjectCollection.get_GlobalProjectCollection()
  at Microsoft.SourceBrowser.Common.AssemblyNameExtractor.GetAssemblyNameFromProject(String projectFilePath)
  at Microsoft.SourceBrowser.Common.AssemblyNameExtractor.GetAssemblyNames(String projectOrSolutionFilePath)
  at Microsoft.SourceBrowser.HtmlGenerator.Program.IndexSolutions(IEnumerable`1 solutionFilePaths, IReadOnlyDictionary`2 properties, Federation federation, IReadOnlyDictionary`2 serverPathMappings, IEnumerable`1 pluginBlacklist, Boolean doNotIncludeReferencedProjects, String rootPath) in C:\SourceBrowser\src\HtmlGenerator\Program.cs:line 125
  at Microsoft.SourceBrowser.HtmlGenerator.Program.Main(String[] args) in C:\SourceBrowser\src\HtmlGenerator\Program.cs:line 20
```

It seems to work at first glance after the update, though maybe I didn't check thoroughly enough.

I kept MSBuild at the current version, as I wasn't sure if you'd rather keep it that way. I just added a `NuGetVersionMSBuild` property for consistency. Also, the MEF assembly references an older version of Roslyn, and I wasn't sure if I should update it, so I left it as-is.
