### PR TITLE
Add Open Search Description Document to enable "Tab to Search"

### DIFF
--- a/src/SourceIndexServer/Controllers/OpenSearchController.cs
+++ b/src/SourceIndexServer/Controllers/OpenSearchController.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.SourceBrowser.SourceIndexServer.Controllers
+{
+    [ApiController]
+    public class OpenSearchController : Controller
+    {
+        [HttpGet("/opensearch")]
+        public IActionResult GetOpenSearchDescriptionDocument()
+        {
+            var pathBase = String.IsNullOrWhiteSpace(Request.PathBase) ? "" : "/" + Request.PathBase;
+            var urlBase = $"{Request.Scheme}://{Request.Host}{pathBase}";
+            var result = String.Join("\r\n",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<OpenSearchDescription xmlns=\"http://a9.com/-/spec/opensearch/1.1/\">",
+                "	<ShortName>Source Browser</ShortName>",
+                $"	<Image height=\"256\" width=\"256\" type=\"image/vnd.microsoft.icon\">{urlBase}/favicon.ico</Image>",
+                $"	<Url type=\"text/html\" template=\"{urlBase}/#q={{searchTerms}}\"></Url>",
+                "</OpenSearchDescription>"
+            );
+            return Content(result, "application/opensearchdescription+xml", Encoding.UTF8);
+        }
+    }
+}

--- a/src/SourceIndexServer/wwwroot/index.html
+++ b/src/SourceIndexServer/wwwroot/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Source Browser</title>
+    <link rel="search" type="application/opensearchdescription+xml" href="opensearch" title="Source Browser">
     <link rel="stylesheet" href="styles.css">
     <script src="scripts.js"></script>
 </head>


### PR DESCRIPTION
This is a feature I think all websites with an essential search function should have. "Tab to Search" lets users type the shortcut, usually the domain name, of a web page then press `TAB` and write a query to instantly search on that page.

I have tested this on Microsoft Edge, Firefox, and Google Chrome. Edge instantly activates discovered search engines, while [Firefox](https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox#w_add-search-engines) and [Chrome](https://support.google.com/chrome/answer/95426#edit) requires manual activation.

I have implemented the Open Search Description Document as an API controller. It will return the XML formatted document with the correct content type. The URL base in the document is based on the request URL, this should allow the document to describe the search feature no matter the deployment URL.