### PR TITLE
Do not use FilePath if multiple documents share it

### DIFF
--- a/src/HtmlGenerator/Utilities/Paths.cs
+++ b/src/HtmlGenerator/Utilities/Paths.cs
@@ -166,7 +166,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 .ToArray());
 
             string fileName;
-            if (document.FilePath != null)
+            if (document.FilePath != null && !document.GetLinkedDocumentIds().Any())
             {
                 fileName = Path.GetFileName(document.FilePath);
             }


### PR DESCRIPTION
Using the Document.Name is the [correct](https://github.com/dotnet/roslyn/issues/12176#issuecomment-265302328) thing to use here, as long as the `<Link>` value is set properly. But an early [commit](https://github.com/KirillOsenkov/SourceBrowser/pull/34) to this repo modified it to use the filename part of Document.FilePath instead, to avoid "File is already used by another process" IO exceptions, which were happening because `<Link>` was not set properly in the project file.

However, with .NET Core .csproj files, sometimes using Document.FilePath can cause the same sort of IO exceptions. In particular, if you have multiple Properties\AssemblyInfo*.cs files, all of them will have the same FilePath value, but the Name value will be the actual filename.

So to fix .NET Core projects like that, while still not breaking the original use case (when `<Link>` is set improperly), this change will use Document.Name if there are multiple files that share the same Document.FilePath.

To find conflicts, we call [GetLinkedDocumentIds](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.document.getlinkeddocumentids?view=roslyn-dotnet-4.3.0#microsoft-codeanalysis-document-getlinkeddocumentids), which says that "Documents are considered to be linked if they share the same FilePath. This DocumentId [of the Document being operated on] is excluded from the result." In other words, if GetLinkedDocumentIds returns an empty array, then there are no other documents in the project that have the same FilePath, so it's safe to use the FilePath. Otherwise, we need to use the Name instead.

(Tested this change both with a project that has an improper `<Link>` value, as well as with the .NET Core .csproj that brought about this change request.)