### PR TITLE
Clean up build warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "SourceBrowser.sln"
+}

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -4,6 +4,11 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\key.snk</AssemblyOriginatorKeyFile>
+    <!-- 
+        The following packages do not have netstandard2.0 versions and hence produce NU1701 
+        warnings: Microsoft.Build, Microsoft.VisualStudio.Setup
+    -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
     <DefineConstants>$(DefineConstants);NET472</DefineConstants>

--- a/src/HtmlGenerator.Tests/HtmlGenerator.Tests.csproj
+++ b/src/HtmlGenerator.Tests/HtmlGenerator.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <NoWarn>$(NoWarn);VSTHRD002;VSTHRD103</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -10,6 +10,7 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>$(NoWarn);VSTHRD002;VSTHRD103</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <NuGetPackageId>SourceBrowser</NuGetPackageId>

--- a/src/HtmlGenerator/Pass1-Generation/Classifier.cs
+++ b/src/HtmlGenerator/Pass1-Generation/Classifier.cs
@@ -11,7 +11,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 {
     public partial class Classification
     {
-        public async Task<IEnumerable<Range>> Classify(Document document, SourceText text)
+        public async Task<IEnumerable<Range>> ClassifyAsync(Document document, SourceText text)
         {
             var span = TextSpan.FromBounds(0, text.Length);
 

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.HighlightReferences.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.HighlightReferences.cs
@@ -5,7 +5,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 {
     public partial class DocumentGenerator
     {
-        private readonly Dictionary<ISymbol, int> localIds = new Dictionary<ISymbol, int>();
+        private readonly Dictionary<ISymbol, int> localIds = new Dictionary<ISymbol, int>(SymbolEqualityComparer.Default);
 
         private HtmlElementInfo HighlightDefinition(ISymbol declaredSymbol)
         {

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.Links.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.Links.cs
@@ -354,11 +354,12 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
         {
             var declaringType = declaredSymbol.ContainingType;
             var interfaces = declaringType.AllInterfaces;
+            var comparer = SymbolEqualityComparer.Default;
             foreach (var implementedInterface in interfaces)
             {
                 foreach (var member in implementedInterface.GetMembers())
                 {
-                    if (declaringType.FindImplementationForInterfaceMember(member) == declaredSymbol)
+                    if (comparer.Equals(declaringType.FindImplementationForInterfaceMember(member), declaredSymbol))
                     {
                         ProcessReference(
                             range,

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.References.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.References.cs
@@ -254,7 +254,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     SemanticModel.GetDeclaredSymbol(typeDeclaration) is INamedTypeSymbol derivedType &&
                     referencedSymbol is INamedTypeSymbol baseSymbol)
                 {
-                    if (baseSymbol.TypeKind == TypeKind.Class && baseSymbol.Equals(derivedType.BaseType))
+                    if (baseSymbol.TypeKind == TypeKind.Class && baseSymbol.Equals(derivedType.BaseType, SymbolEqualityComparer.Default))
                     {
                         kind = ReferenceKind.DerivedType;
                     }

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -38,7 +38,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             this.Document = document;
         }
 
-        public async Task Generate()
+        public async Task GenerateAsync()
         {
             if (Configuration.CalculateRoslynSemantics)
             {
@@ -113,7 +113,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     append: false,
                     encoding: Encoding.UTF8))
                 {
-                    await GenerateHtml(streamWriter);
+                    await GenerateHtmlAsync(streamWriter);
                 }
             }
             else
@@ -121,7 +121,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 using (var memoryStream = new MemoryStream())
                 using (var streamWriter = new StreamWriter(memoryStream))
                 {
-                    await GeneratePre(streamWriter);
+                    await GeneratePreAsync(streamWriter);
                 }
             }
         }
@@ -137,7 +137,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             this.relativePathToRoot = Paths.CalculateRelativePathToRoot(documentDestinationFilePath, SolutionDestinationFolder);
         }
 
-        private async Task GenerateHtml(StreamWriter writer)
+        private async Task GenerateHtmlAsync(StreamWriter writer)
         {
             var title = Document.Name;
             var lineCount = Text.Lines.Count;
@@ -148,21 +148,21 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
 
             // pass a value larger than 0 to generate line numbers in JavaScript (to reduce HTML size)
             var prefix = Markup.GetDocumentPrefix(title, relativePathToRoot, pregenerateLineNumbers ? 0 : lineCount);
-            writer.Write(prefix);
+            await writer.WriteAsync(prefix);
             GenerateHeader(writer.WriteLine);
 
-            var ranges = (await classifier.Classify(Document, Text))?.ToArray();
+            var ranges = (await classifier.ClassifyAsync(Document, Text))?.ToArray();
 
             // pass a value larger than 0 to generate line numbers statically at HTML generation time
             var table = Markup.GetTablePrefix(
                 DocumentUrl,
                 pregenerateLineNumbers ? lineCount : 0,
                 GenerateGlyphs(ranges));
-            writer.WriteLine(table);
+            await writer.WriteLineAsync(table);
 
             GeneratePre(ranges, writer, lineCount);
             var suffix = Markup.GetDocumentSuffix();
-            writer.WriteLine(suffix);
+            await writer.WriteLineAsync(suffix);
         }
 
         private ISymbol GetSymbolForRange(Classification.Range r)
@@ -285,9 +285,9 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 projectLink: (Display: projectGenerator.ProjectSourcePath, Url: "/#" + Document.Project.AssemblyName, projectGenerator.AssemblyName));
         }
 
-        private async Task GeneratePre(StreamWriter writer, int lineCount = 0)
+        private async Task GeneratePreAsync(StreamWriter writer, int lineCount = 0)
         {
-            var ranges = await classifier.Classify(Document, Text);
+            var ranges = await classifier.ClassifyAsync(Document, Text);
             GeneratePre(ranges, writer, lineCount);
         }
 

--- a/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/DocumentGenerator.cs
@@ -58,7 +58,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                 this.getBindableParentDelegate = (Func<SyntaxToken, SyntaxNode>)
                     Delegate.CreateDelegate(typeof(Func<SyntaxToken, SyntaxNode>), SyntaxFactsService, getBindableParent);
 
-                this.DeclaredSymbols = new HashSet<ISymbol>();
+                this.DeclaredSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
 
                 Interlocked.Increment(ref projectGenerator.DocumentCount);
                 Interlocked.Add(ref projectGenerator.LinesOfCode, Text.Lines.Count);

--- a/src/HtmlGenerator/Pass1-Generation/MetadataAsSource.cs
+++ b/src/HtmlGenerator/Pass1-Generation/MetadataAsSource.cs
@@ -90,7 +90,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         addSourceToAsync = ReflectAddSourceToAsync(metadataAsSourceService);
                     }
 
-                    var texts = new Dictionary<INamedTypeSymbol, string>();
+                    var texts = new Dictionary<INamedTypeSymbol, string>(SymbolEqualityComparer.Default);
 
                     Parallel.ForEach(
                         types,

--- a/src/HtmlGenerator/Pass1-Generation/MetadataAsSource.cs
+++ b/src/HtmlGenerator/Pass1-Generation/MetadataAsSource.cs
@@ -16,7 +16,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
     {
         private static Func<Document, ISymbol, CancellationToken, Task<Document>> addSourceToAsync = null;
 
-        private static Func<Document, ISymbol, CancellationToken, Task<Document>> ReflectAddSourceToAsync(object service)
+        private static Func<Document, ISymbol, CancellationToken, Task<Document>> ReflectAddSourceTo(object service)
         {
             var assembly = Assembly.Load("Microsoft.CodeAnalysis.Features");
             var type = assembly.GetType("Microsoft.CodeAnalysis.MetadataAsSource.IMetadataAsSourceService");
@@ -87,7 +87,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     var metadataAsSourceService = WorkspaceHacks.GetMetadataAsSourceService(tempDocument);
                     if (addSourceToAsync == null)
                     {
-                        addSourceToAsync = ReflectAddSourceToAsync(metadataAsSourceService);
+                        addSourceToAsync = ReflectAddSourceTo(metadataAsSourceService);
                     }
 
                     var texts = new Dictionary<INamedTypeSymbol, string>(SymbolEqualityComparer.Default);

--- a/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
@@ -35,8 +35,8 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             this.SolutionGenerator = solutionGenerator;
             this.Project = project;
             this.ProjectFilePath = project.FilePath ?? solutionGenerator.ProjectFilePath;
-            this.DeclaredSymbols = new Dictionary<ISymbol, string>();
-            this.BaseMembers = new Dictionary<ISymbol, ISymbol>();
+            this.DeclaredSymbols = new Dictionary<ISymbol, string>(SymbolEqualityComparer.Default);
+            this.BaseMembers = new Dictionary<ISymbol, ISymbol>(SymbolEqualityComparer.Default);
             this.ImplementedInterfaceMembers = new MultiDictionary<ISymbol, ISymbol>();
             this.assemblyAttributesFileName = MetadataAsSource.GeneratedAssemblyAttributesFileName + (project.Language == LanguageNames.CSharp ? ".cs" : ".vb");
             PluginSymbolVisitors = SolutionGenerator.PluginAggregator?.ManufactureSymbolVisitors(project).ToArray();

--- a/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/ProjectGenerator.cs
@@ -81,7 +81,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             this.OtherFiles = new List<string>();
         }
 
-        public async Task Generate()
+        public async Task GenerateAsync()
         {
             try
             {
@@ -135,7 +135,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                             {
                                 while (partition.MoveNext())
                                 {
-                                  await GenerateDocument(partition.Current);
+                                  await GenerateDocumentAsync(partition.Current);
                                 }
                             }
                         }));
@@ -167,7 +167,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     GenerateIndex();
                 }
 
-                var compilation = Project.GetCompilationAsync().Result;
+                var compilation = await Project.GetCompilationAsync();
                 var diagnostics = compilation.GetDiagnostics().Select(d => d.ToString()).ToArray();
                 if (diagnostics.Length > 0)
                 {
@@ -198,17 +198,17 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
             NamespaceExplorer.WriteNamespaceExplorer(this.AssemblyName, symbols, ProjectDestinationFolder);
         }
 
-        private Task GenerateDocument(Document document)
+        private async Task GenerateDocumentAsync(Document document)
         {
             try
             {
                 var documentGenerator = new DocumentGenerator(this, document);
-                return documentGenerator.Generate();
+                await documentGenerator.GenerateAsync();
             }
             catch (Exception e)
             {
                 Log.Exception(e, "Document generation failed for: " + (document.FilePath ?? document.ToString()));
-                return Task.FromResult(e);
+                throw;
             }
         }
 

--- a/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
+++ b/src/HtmlGenerator/Pass1-Generation/SolutionGenerator.cs
@@ -324,7 +324,7 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                     CurrentAssemblyName = project.AssemblyName;
 
                     var generator = new ProjectGenerator(this, project);
-                    generator.Generate().GetAwaiter().GetResult();
+                    generator.GenerateAsync().GetAwaiter().GetResult();
 
                     File.AppendAllText(Paths.ProcessedAssemblies, project.AssemblyName + Environment.NewLine, Encoding.UTF8);
                 }


### PR DESCRIPTION
This clean up all the warnings I saw during build. This PR has three commits, one for each category of warnings that I found: 

- NU1701: there are several packages that don't have `netstandard2.0` equivalents that generate warnings. An alternative fix here would be, at least for `Microsoft.Build`, to upgrade to newer packages but that would potentially impact consumers that wanted to keep using 16.8 (not sure how important that is). 
- Roslyn symbol equality: just fixed these by using `SymbolEqualityComparer.Default` 
- VS Threading: this was more complicated. 
    - naming rules: this was simple enough so just followed the rules 
    - synchronous blocking: this was tough. In a number of places there were fairly obvious code changes (like use `await x` instead of `x.GetAwaiter().GetResult()`. In other cases there were not obvious changes to be made. Ended up suppressing at the project level once I fixed up the easy case. Happy to move suppression to the individual call sites (there are ~6 of them). 

Can also see an argument for disabling the VSTHRD rules altogether as this is not really a VS project hence doesn't need to follow them. 

Happy to change this as requested or have it closed as it wasn't requested but it was bothering me during local development. 