### PR TITLE
Update Roslyn to v4.8.0

### DIFF
--- a/TestCode/Project2/Class1.cs
+++ b/TestCode/Project2/Class1.cs
@@ -170,3 +170,11 @@ class TargetedTypeNewTest
         return new(new());
     }
 }
+
+class TypeWithPrimaryConstructor(A a, B b)
+{
+    public A A => a;
+    public B[] ArrayOfB => [b];
+}
+
+class EmptyType;

--- a/TestCode/TestSolution_EdgeDriver_Tests/TestSolution_EdgeDriver_Tests.csproj
+++ b/TestCode/TestSolution_EdgeDriver_Tests/TestSolution_EdgeDriver_Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -16,7 +16,7 @@
     <NuGetPackageId>SourceBrowser</NuGetPackageId>
     <NuSpecFile>$(MSBuildProjectDirectory)\$(NuGetPackageId).nuspec</NuSpecFile>
     <NuGetVersion>1.0.43</NuGetVersion>
-    <NuGetVersionRoslyn>4.4.0</NuGetVersionRoslyn>
+    <NuGetVersionRoslyn>4.8.0</NuGetVersionRoslyn>
     <NuGetVersionMSBuild>16.10.0</NuGetVersionMSBuild>
   </PropertyGroup>
   <ItemGroup>
@@ -39,14 +39,11 @@
     <PackageReference Include="ManagedEsent" Version="2.0.0" />
     <PackageReference Include="Microsoft.Build" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(NuGetVersionRoslyn)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(NuGetVersionRoslyn)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(NuGetVersionRoslyn)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(NuGetVersionRoslyn)" />


### PR DESCRIPTION
This updates Roslyn to v4.8.0.

C# 12 stuff seems to work fine with no other changes, so this PR is straightforward. I upgraded the EdgeDriver test project target framework because of a security vulnerability that generated an error message.
