### PR TITLE
Update Roslyn to v4.12.0

### DIFF
--- a/TestCode/Project2/Class1.cs
+++ b/TestCode/Project2/Class1.cs
@@ -178,3 +178,9 @@ class TypeWithPrimaryConstructor(A a, B b)
 }
 
 class EmptyType;
+
+class TypeWithAllowsRefStruct<T>
+    where T : allows ref struct
+{
+    public static T Return(T value) => value;
+}

--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -16,8 +16,8 @@
     <NuGetPackageId>SourceBrowser</NuGetPackageId>
     <NuSpecFile>$(MSBuildProjectDirectory)\$(NuGetPackageId).nuspec</NuSpecFile>
     <NuGetVersion>1.0.46</NuGetVersion>
-    <NuGetVersionRoslyn>4.8.0</NuGetVersionRoslyn>
-    <NuGetVersionMSBuild>17.5.0</NuGetVersionMSBuild>
+    <NuGetVersionRoslyn>4.12.0</NuGetVersionRoslyn>
+    <NuGetVersionMSBuild>17.12.6</NuGetVersionMSBuild>
   </PropertyGroup>
   <ItemGroup>
     <NuGetInput Include="$(MSBuildThisFile)" />
@@ -39,7 +39,7 @@
     <PackageReference Include="ManagedEsent" Version="2.0.0" />
     <PackageReference Include="Microsoft.Build" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(NuGetVersionRoslyn)" />
@@ -57,6 +57,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.10.230" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />

--- a/src/HtmlGenerator/app.config
+++ b/src/HtmlGenerator/app.config
@@ -8,5 +8,24 @@
     <DisableFXClosureWalk enabled="true" />
     <appDomainManagerType value="Microsoft.SourceBrowser.Common.CustomAppDomainManager"/>
     <appDomainManagerAssembly value="Microsoft.SourceBrowser.Common"/>
+
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5"/>
+      </dependentAssembly>
+    </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
I noticed that generic arguments were not bound when `where T : allows ref struct` was specified.