### PR TITLE
Fix missing BuildHost

### DIFF
--- a/src/HtmlGenerator/SourceBrowser.nuspec
+++ b/src/HtmlGenerator/SourceBrowser.nuspec
@@ -22,6 +22,8 @@
     <file src="*.exe" target="tools" />
     <file src="*.exe.config" target="tools" />
     <file src="*.dll" target="tools" />
+    <file src="BuildHost-net472\*.*" target="tools\BuildHost-net472" />
+    <file src="BuildHost-netcore\*.*" target="tools\BuildHost-netcore" />
     <file src="TypeScriptSupport\*.*" target="tools\TypeScriptSupport" />
     <file src="web\**\*" target="tools\web" />
   </files>


### PR DESCRIPTION
Sorry I didn't notice this before I made my previous PR, but apparently the previous Roslyn version shipped a single BuildHost (the `Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe` file along with its dependencies), whereas the new version of the `Microsoft.CodeAnalysis.Workspaces.MSBuild` package ships two of those in the `BuildHost-net472` and `BuildHost-netcore` subdirectories, and those were missing in the SourceBrowser package.

Note that I didn't include the BuildHost language resource files since the CodeAnalysis ones were already omitted.
